### PR TITLE
Corrige gerenciamento de usuários (admin): edição/exclusão e endurecimento das APIs

### DIFF
--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -1,18 +1,48 @@
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
-import { Plus, Users, Shield, UserPlus, Settings, Edit } from "lucide-react";
+import { Users, Shield, UserPlus, Settings, Edit, Trash2 } from "lucide-react";
 import Header from "@/components/layout/header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { DefaultMobileDrawer } from "@/components/layout/mobile-layout";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/useAuth";
 import type { User } from "@shared/schema";
 
 export default function AdminDashboard() {
   const [, setLocation] = useLocation();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { user: currentUser } = useAuth();
+  const [userToDelete, setUserToDelete] = useState<User | null>(null);
 
   const { data: users = [], isLoading } = useQuery<User[]>({
     queryKey: ["/api/admin/users"],
+  });
+
+  const deleteUserMutation = useMutation({
+    mutationFn: (userId: string) => apiRequest("DELETE", `/api/admin/users/${userId}`),
+    onSuccess: () => {
+      toast({
+        title: "Usuário excluído com sucesso!",
+        description: "A lista foi atualizada automaticamente.",
+      });
+      setUserToDelete(null);
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erro ao excluir usuário",
+        description: error?.message?.includes("403")
+          ? "Você não pode excluir sua própria conta."
+          : "Não foi possível excluir este usuário.",
+        variant: "destructive",
+      });
+    },
   });
 
   const userStats = {
@@ -172,16 +202,29 @@ export default function AdminDashboard() {
                           {user.createdAt && formatDate(user.createdAt.toString())}
                         </td>
                         <td className="p-4">
-                          <Button 
-                            variant="ghost" 
-                            size="sm"
-                            onClick={() => setLocation(`/admin/users/${user.id}`)}
-                            className="flex items-center space-x-2"
-                            data-testid={`button-edit-user-${user.id}`}
-                          >
-                            <Edit className="h-4 w-4" />
-                            <span>Editar</span>
-                          </Button>
+                          <div className="flex items-center gap-2">
+                            <Button 
+                              variant="ghost" 
+                              size="sm"
+                              onClick={() => setLocation(`/admin/users/${user.id}`)}
+                              className="flex items-center space-x-2"
+                              data-testid={`button-edit-user-${user.id}`}
+                            >
+                              <Edit className="h-4 w-4" />
+                              <span>Editar</span>
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setUserToDelete(user)}
+                              className="flex items-center space-x-2 text-destructive hover:text-destructive"
+                              disabled={deleteUserMutation.isPending || user.id === currentUser?.id}
+                              data-testid={`button-delete-user-${user.id}`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              <span>Excluir</span>
+                            </Button>
+                          </div>
                         </td>
                       </tr>
                     ))
@@ -192,6 +235,27 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
       </main>
+
+      <AlertDialog open={!!userToDelete} onOpenChange={(open) => !open && setUserToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmar exclusão</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tem certeza que deseja excluir <strong>{userToDelete?.firstName} {userToDelete?.lastName}</strong>? Esta ação não pode ser desfeita.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteUserMutation.isPending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteUserMutation.isPending || !userToDelete}
+              onClick={() => userToDelete && deleteUserMutation.mutate(userToDelete.id)}
+            >
+              {deleteUserMutation.isPending ? "Excluindo..." : "Excluir"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,6 +22,37 @@ import ExcelJS from 'exceljs';
 
 const SALT_ROUNDS = 10;
 const BRAZIL_TIMEZONE = 'America/Sao_Paulo';
+const VALID_USER_ROLES = ["admin", "nutritionist", "patient", "fito"] as const;
+
+type SafeUserResponse = {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  profileImageUrl: string | null;
+  role: string;
+  bodyFatEquation: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+function isValidUserId(id: string): boolean {
+  return typeof id === "string" && id.trim().length > 0 && id.length <= 128;
+}
+
+function sanitizeUser(user: any): SafeUserResponse {
+  return {
+    id: user.id,
+    email: user.email,
+    firstName: user.firstName ?? null,
+    lastName: user.lastName ?? null,
+    profileImageUrl: user.profileImageUrl ?? null,
+    role: user.role,
+    bodyFatEquation: user.bodyFatEquation ?? null,
+    createdAt: user.createdAt ?? null,
+    updatedAt: user.updatedAt ?? null,
+  };
+}
 
 function formatDateInBrazilTimezone(value: Date | string | null | undefined, includeTime = false): string {
   if (!value) return 'N/A';
@@ -227,16 +258,43 @@ export async function setupRoutes(app: Express): Promise<void> {
   app.get('/api/admin/users', isAuthenticated, isAdmin, async (req, res) => {
     try {
         const users = await storage.getAllUsers();
-        res.json(users);
+        res.json(users.map((user) => sanitizeUser(user)));
     } catch (error) {
         console.error("Erro ao buscar usuários:", error);
         res.status(500).json({ message: "Falha ao buscar usuários." });
     }
   });
 
+  app.get('/api/admin/users/:id', isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidUserId(id)) {
+        return res.status(400).json({ message: "ID de usuário inválido." });
+      }
+
+      const user = await storage.getUser(id);
+      if (!user) {
+        return res.status(404).json({ message: "Usuário não encontrado." });
+      }
+
+      res.json(sanitizeUser(user));
+    } catch (error) {
+      console.error("Erro ao buscar usuário por ID:", error);
+      res.status(500).json({ message: "Falha ao buscar usuário." });
+    }
+  });
+
   app.get('/api/admin/users/:id/dependencies', isAuthenticated, isAdmin, async (req, res) => {
     try {
       const { id } = req.params;
+      if (!isValidUserId(id)) {
+        return res.status(400).json({ message: "ID de usuário inválido." });
+      }
+      const user = await storage.getUser(id);
+      if (!user) {
+        return res.status(404).json({ message: "Usuário não encontrado." });
+      }
+
       const hasPatients = await storage.userHasPatients(id);
       const hasPrescriptions = await storage.userHasPrescriptions(id);
       const hasInvitations = await storage.userHasInvitations(id);
@@ -261,7 +319,7 @@ export async function setupRoutes(app: Express): Promise<void> {
 
         const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
         const newUser = await storage.upsertUser({ email, hashedPassword, firstName, lastName, role });
-        res.status(201).json(newUser);
+        res.status(201).json(sanitizeUser(newUser));
     } catch (error) {
         console.error("Erro ao criar usuário:", error);
         res.status(500).json({ message: "Falha ao criar usuário." });
@@ -270,8 +328,33 @@ export async function setupRoutes(app: Express): Promise<void> {
 
   app.put('/api/admin/users/:id', isAuthenticated, isAdmin, async (req, res) => {
       try {
-        const updatedUser = await storage.updateUserProfile(req.params.id, req.body);
-        res.json(updatedUser);
+        const { id } = req.params;
+        if (!isValidUserId(id)) {
+          return res.status(400).json({ message: "ID de usuário inválido." });
+        }
+
+        const existingUser = await storage.getUser(id);
+        if (!existingUser) {
+          return res.status(404).json({ message: "Usuário não encontrado." });
+        }
+
+        const allowedPayload = {
+          firstName: typeof req.body?.firstName === "string" ? req.body.firstName.trim() : "",
+          lastName: typeof req.body?.lastName === "string" ? req.body.lastName.trim() : "",
+          email: typeof req.body?.email === "string" ? req.body.email.trim().toLowerCase() : "",
+          role: req.body?.role,
+        };
+
+        if (!allowedPayload.firstName || !allowedPayload.lastName || !allowedPayload.email) {
+          return res.status(400).json({ message: "Nome, sobrenome e email são obrigatórios." });
+        }
+
+        if (!VALID_USER_ROLES.includes(allowedPayload.role)) {
+          return res.status(400).json({ message: "Role de usuário inválida." });
+        }
+
+        const updatedUser = await storage.updateUserProfile(id, allowedPayload);
+        res.json(sanitizeUser(updatedUser));
       } catch (error: any) {
         console.error("Erro ao atualizar usuário:", error);
         if (error.message?.includes('unique constraint')) {
@@ -283,12 +366,21 @@ export async function setupRoutes(app: Express): Promise<void> {
 
   app.put('/api/admin/users/:id/password', isAuthenticated, isAdmin, async (req, res) => {
       try {
+          const { id } = req.params;
+          if (!isValidUserId(id)) {
+            return res.status(400).json({ message: "ID de usuário inválido." });
+          }
+          const existingUser = await storage.getUser(id);
+          if (!existingUser) {
+            return res.status(404).json({ message: "Usuário não encontrado." });
+          }
+
           const { newPassword } = req.body;
           if (!newPassword || newPassword.length < 6) {
               return res.status(400).json({ message: "A nova senha deve ter pelo menos 6 caracteres." });
           }
           const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
-          await storage.updateUserPassword(req.params.id, hashedPassword);
+          await storage.updateUserPassword(id, hashedPassword);
           res.status(200).json({ message: "Senha atualizada com sucesso." });
       } catch (error) {
           console.error("Erro ao alterar senha:", error);
@@ -298,7 +390,21 @@ export async function setupRoutes(app: Express): Promise<void> {
   
   app.delete('/api/admin/users/:id', isAuthenticated, isAdmin, async (req, res) => {
     try {
-      await storage.deleteUser(req.params.id);
+      const { id } = req.params;
+      if (!isValidUserId(id)) {
+        return res.status(400).json({ message: "ID de usuário inválido." });
+      }
+
+      const existingUser = await storage.getUser(id);
+      if (!existingUser) {
+        return res.status(404).json({ message: "Usuário não encontrado." });
+      }
+
+      if ((req.user as any).id === id) {
+        return res.status(403).json({ message: "Você não pode excluir sua própria conta administrativa." });
+      }
+
+      await storage.deleteUser(id);
       res.status(204).send();
     } catch (error: any) {
       console.error("Erro ao deletar usuário:", error);


### PR DESCRIPTION
### Motivation
- A página de edição do admin requisitava `GET /api/admin/users/:id`, rota que não existia, impedindo carregar dados para editar/excluir usuários. 
- Foi necessário reforçar segurança/validação no backend e habilitar ações diretas de exclusão no frontend com feedback visual e atualização automática da lista.

### Description
- Adicionada rota `GET /api/admin/users/:id` e sanitização das respostas para nunca expor `hashedPassword`, via `sanitizeUser` (arquivo `server/routes.ts`).
- Endpoints admin foram endurecidos com validação de ID (400), retorno `404` para usuário inexistente, allowlist de payload em updates (`firstName`, `lastName`, `email`, `role`), validação de role permitida e proteção contra autoexclusão do próprio admin (403) (arquivo `server/routes.ts`).
- Ajustado `POST /api/admin/users` e dependências para retornar usuário sanitizado e validar existência antes de operações sensíveis (arquivo `server/routes.ts`).
- Frontend: adicionado botão `Excluir` por linha na tabela do admin com `AlertDialog` de confirmação, `useMutation` para `DELETE /api/admin/users/:id`, toasts de sucesso/erro, estados de loading e `queryClient.invalidateQueries` para atualizar a lista automaticamente (arquivo `client/src/pages/admin/dashboard.tsx`).
- Arquivos alterados: `server/routes.ts`, `client/src/pages/admin/dashboard.tsx`.

### Testing
- Executei checagem de tipo com `npm run check` (`tsc`); o comando falhou devido a erros TypeScript pré-existentes em módulos não relacionados a este escopo (ex.: `client/src/pages/nutritionist/patient-details.tsx`), portanto a verificação global ficou com falha e não impede o uso das rotas/fluxos corrigidos localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb292bd5e0833180c3ba6d22e40510)