### PR TITLE
feat: improve patient evolution visualization with safe historical comparison

### DIFF
--- a/client/src/components/assessment-evolution.tsx
+++ b/client/src/components/assessment-evolution.tsx
@@ -6,6 +6,7 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -132,18 +133,48 @@ function getVariation(current: number | null, previous: number | null) {
 
   const absolute = Number((current - previous).toFixed(2));
   const percent = previous === 0 ? null : Number((((current - previous) / previous) * 100).toFixed(2));
-
   const trend = absolute === 0 ? "Sem alteração" : absolute > 0 ? "Aumento" : "Redução";
 
   return { absolute, percent, trend };
 }
 
-function SectionHeader({ icon, title }: { icon: React.ReactNode; title: string }) {
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+}) {
   return (
-    <div className="flex items-center gap-2 mb-3">
-      <div className="w-7 h-7 rounded-lg bg-purple-50 flex items-center justify-center">{icon}</div>
-      <p className="text-xs font-bold text-foreground uppercase tracking-widest">{title}</p>
+    <div className="mb-3">
+      <div className="flex items-center gap-2">
+        <div className="w-7 h-7 rounded-lg bg-purple-50 flex items-center justify-center">{icon}</div>
+        <p className="text-xs font-bold text-foreground uppercase tracking-widest">{title}</p>
+      </div>
+      {subtitle && <p className="text-[11px] text-muted-foreground mt-1">{subtitle}</p>}
     </div>
+  );
+}
+
+function SingleMetricLegend({ label, color }: { label: string; color: string }) {
+  return (
+    <div className="flex items-center justify-center pb-1">
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-2 py-1 text-[10px] text-muted-foreground">
+        <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function ComparisonBadge({ label, value, variant = "outline" }: { label: string; value: string; variant?: "outline" | "secondary" }) {
+  return (
+    <Badge variant={variant} className="text-[10px] font-medium px-2.5 py-1">
+      <span className="text-muted-foreground mr-1">{label}:</span>
+      <span>{value}</span>
+    </Badge>
   );
 }
 
@@ -175,7 +206,6 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
 
   const comparisonStart = sortedHistory[compareStartIndex] ?? null;
   const comparisonEnd = sortedHistory[compareEndIndex] ?? null;
-  const previousForEnd = compareEndIndex > 0 ? sortedHistory[compareEndIndex - 1] : null;
 
   const dayInterval = getDayDiff(firstAssessment?.createdAt, latestAssessment?.createdAt);
 
@@ -266,7 +296,7 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
 
   if (!latestAssessment) {
     return (
-      <Card className="border border-border/70">
+      <Card className="border border-border/70 shadow-sm">
         <CardContent className="flex flex-col items-center justify-center py-12 text-center">
           <Activity className="h-12 w-12 text-muted-foreground/50 mb-4" />
           <p className="text-muted-foreground font-medium">Você ainda não possui avaliações registradas.</p>
@@ -281,7 +311,7 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
   if (sortedHistory.length === 1) {
     return (
       <div className="space-y-4">
-        <Card className="border border-purple-100 bg-purple-50/40">
+        <Card className="border border-purple-100 bg-purple-50/40 shadow-sm">
           <CardContent className="px-4 py-3 flex items-center gap-3">
             <div className="w-9 h-9 rounded-xl bg-purple-100 flex items-center justify-center">
               <Calendar className="h-4 w-4 text-purple-600" />
@@ -295,7 +325,7 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
           </CardContent>
         </Card>
 
-        <Card className="border border-border/50">
+        <Card className="border border-border/60 shadow-sm">
           <CardContent className="flex flex-col items-center justify-center py-10 text-center">
             <ArrowRightLeft className="h-10 w-10 text-purple-300 mb-3" />
             <p className="text-sm font-medium text-muted-foreground">Você possui uma avaliação registrada.</p>
@@ -316,26 +346,26 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
         transition={{ duration: 0.3 }}
         className="grid grid-cols-2 lg:grid-cols-4 gap-2.5"
       >
-        <Card className="border border-gray-100">
-          <CardContent className="p-3">
+        <Card className="border border-gray-100 shadow-sm">
+          <CardContent className="p-3.5">
             <p className="text-[11px] text-muted-foreground">Total de avaliações</p>
-            <p className="text-lg font-bold">{sortedHistory.length}</p>
+            <p className="text-lg font-bold text-foreground">{sortedHistory.length}</p>
           </CardContent>
         </Card>
-        <Card className="border border-gray-100">
-          <CardContent className="p-3">
+        <Card className="border border-gray-100 shadow-sm">
+          <CardContent className="p-3.5">
             <p className="text-[11px] text-muted-foreground">Primeira avaliação</p>
             <p className="text-sm font-semibold leading-tight">{formatDate(firstAssessment?.createdAt)}</p>
           </CardContent>
         </Card>
-        <Card className="border border-gray-100">
-          <CardContent className="p-3">
+        <Card className="border border-gray-100 shadow-sm">
+          <CardContent className="p-3.5">
             <p className="text-[11px] text-muted-foreground">Última avaliação</p>
             <p className="text-sm font-semibold leading-tight">{formatDate(latestAssessment?.createdAt)}</p>
           </CardContent>
         </Card>
-        <Card className="border border-gray-100">
-          <CardContent className="p-3">
+        <Card className="border border-gray-100 shadow-sm">
+          <CardContent className="p-3.5">
             <p className="text-[11px] text-muted-foreground">Período acompanhado</p>
             <p className="text-sm font-semibold leading-tight">
               {dayInterval == null ? "Não disponível" : `${dayInterval} dia${dayInterval === 1 ? "" : "s"}`}
@@ -344,14 +374,24 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
         </Card>
       </motion.div>
 
-      <Card className="border border-purple-100 bg-purple-50/30">
+      <Card className="border border-purple-100 bg-purple-50/30 shadow-sm">
         <CardContent className="p-4 space-y-3">
-          <SectionHeader icon={<ArrowRightLeft className="h-3.5 w-3.5 text-purple-600" />} title="Comparação entre avaliações" />
+          <SectionHeader
+            icon={<ArrowRightLeft className="h-3.5 w-3.5 text-purple-600" />}
+            title="Comparação entre avaliações"
+            subtitle="Padrão: primeira avaliação até a última avaliação registrada."
+          />
+
+          <div className="flex flex-wrap gap-2">
+            <ComparisonBadge label="Inicial" value={formatDate(comparisonStart?.createdAt)} />
+            <ComparisonBadge label="Final" value={formatDate(comparisonEnd?.createdAt)} variant="secondary" />
+          </div>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label className="text-xs text-muted-foreground">Comparar de</Label>
               <Select value={comparisonStart?.id ?? ""} onValueChange={setFromId}>
-                <SelectTrigger>
+                <SelectTrigger className="bg-background/80">
                   <SelectValue placeholder="Selecione" />
                 </SelectTrigger>
                 <SelectContent>
@@ -366,7 +406,7 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
             <div className="space-y-1.5">
               <Label className="text-xs text-muted-foreground">Comparar até</Label>
               <Select value={comparisonEnd?.id ?? ""} onValueChange={setToId}>
-                <SelectTrigger>
+                <SelectTrigger className="bg-background/80">
                   <SelectValue placeholder="Selecione" />
                 </SelectTrigger>
                 <SelectContent>
@@ -394,9 +434,13 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
       </Card>
 
       <div>
-        <SectionHeader icon={<Activity className="h-3.5 w-3.5 text-indigo-600" />} title="Variação por métrica" />
+        <SectionHeader
+          icon={<Activity className="h-3.5 w-3.5 text-indigo-600" />}
+          title="Variação por métrica"
+          subtitle="Exibe apenas métricas com valor inicial e final válidos no intervalo selecionado."
+        />
         {comparisonMetrics.length === 0 ? (
-          <Card className="border border-border/70">
+          <Card className="border border-border/70 shadow-sm">
             <CardContent className="py-6 text-center text-sm text-muted-foreground">
               Não há métricas numéricas completas para comparar nesse intervalo.
             </CardContent>
@@ -413,14 +457,19 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                   <ArrowDown className="h-3.5 w-3.5" />
                 );
 
+              const trendClasses =
+                metric.variation.absolute == null || metric.variation.absolute === 0
+                  ? "bg-slate-100 text-slate-700"
+                  : metric.variation.absolute > 0
+                  ? "bg-blue-100 text-blue-700"
+                  : "bg-emerald-100 text-emerald-700";
+
               return (
-                <Card key={metric.key} className="border border-gray-100">
+                <Card key={metric.key} className="border border-gray-100 shadow-sm">
                   <CardContent className="p-3 space-y-2">
                     <div className="flex items-center justify-between gap-3">
                       <p className="text-sm font-semibold">{metric.label}</p>
-                      <Badge variant="secondary" className="text-[10px]">
-                        {metric.variation.trend}
-                      </Badge>
+                      <Badge className={`text-[10px] border-0 ${trendClasses}`}>{metric.variation.trend}</Badge>
                     </div>
                     <div className="grid grid-cols-3 gap-2 text-xs">
                       <div>
@@ -461,11 +510,15 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
 
       {weightData.length >= 2 && (
         <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.1 }}>
-          <SectionHeader icon={<Weight className="h-3.5 w-3.5 text-blue-500" />} title="Evolução do Peso" />
+          <SectionHeader
+            icon={<Weight className="h-3.5 w-3.5 text-blue-500" />}
+            title="Evolução do Peso"
+            subtitle="Linha temporal de peso (kg) em ordem cronológica."
+          />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={190}>
-                <AreaChart data={weightData} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
+              <ResponsiveContainer width="100%" height={220}>
+                <AreaChart data={weightData} margin={{ top: 8, right: 12, left: -20, bottom: 8 }}>
                   <defs>
                     <linearGradient id="weightGrad" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%" stopColor="#3B82F6" stopOpacity={0.25} />
@@ -482,15 +535,27 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                       return (
                         <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
                           <p className="text-xs text-muted-foreground">{point.dateLong}</p>
-                          <p className="text-[11px] text-muted-foreground">{point.title}</p>
+                          <p className="text-[11px] text-muted-foreground mb-0.5">{point.title}</p>
+                          <p className="text-xs text-muted-foreground">Métrica: Peso</p>
                           <p className="text-sm font-bold text-blue-600">{formatNumber(point.value)} kg</p>
                         </div>
                       );
                     }}
                   />
-                  <Area type="monotone" dataKey="value" stroke="#3B82F6" strokeWidth={2.5} fill="url(#weightGrad)" dot={{ r: 4, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }} activeDot={{ r: 6, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }} />
+                  <Legend verticalAlign="bottom" align="center" wrapperStyle={{ paddingTop: 8, fontSize: 11 }} />
+                  <Area
+                    type="monotone"
+                    dataKey="value"
+                    name="Peso"
+                    stroke="#3B82F6"
+                    strokeWidth={2.5}
+                    fill="url(#weightGrad)"
+                    dot={{ r: 4, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }}
+                    activeDot={{ r: 6, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }}
+                  />
                 </AreaChart>
               </ResponsiveContainer>
+              <SingleMetricLegend label="Peso" color="#3B82F6" />
             </CardContent>
           </Card>
         </motion.div>
@@ -498,11 +563,15 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
 
       {fatData.length >= 2 && (
         <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.15 }}>
-          <SectionHeader icon={<Percent className="h-3.5 w-3.5 text-orange-500" />} title="Evolução da Gordura Corporal" />
+          <SectionHeader
+            icon={<Percent className="h-3.5 w-3.5 text-orange-500" />}
+            title="Evolução da Gordura Corporal"
+            subtitle="Linha temporal do percentual de gordura (%)."
+          />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={190}>
-                <AreaChart data={fatData} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
+              <ResponsiveContainer width="100%" height={220}>
+                <AreaChart data={fatData} margin={{ top: 8, right: 12, left: -20, bottom: 8 }}>
                   <defs>
                     <linearGradient id="fatGrad" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%" stopColor="#F97316" stopOpacity={0.25} />
@@ -519,15 +588,27 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                       return (
                         <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
                           <p className="text-xs text-muted-foreground">{point.dateLong}</p>
-                          <p className="text-[11px] text-muted-foreground">{point.title}</p>
+                          <p className="text-[11px] text-muted-foreground mb-0.5">{point.title}</p>
+                          <p className="text-xs text-muted-foreground">Métrica: % Gordura</p>
                           <p className="text-sm font-bold text-orange-600">{formatNumber(point.value)}%</p>
                         </div>
                       );
                     }}
                   />
-                  <Area type="monotone" dataKey="value" stroke="#F97316" strokeWidth={2.5} fill="url(#fatGrad)" dot={{ r: 4, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }} activeDot={{ r: 6, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }} />
+                  <Legend verticalAlign="bottom" align="center" wrapperStyle={{ paddingTop: 8, fontSize: 11 }} />
+                  <Area
+                    type="monotone"
+                    dataKey="value"
+                    name="% Gordura"
+                    stroke="#F97316"
+                    strokeWidth={2.5}
+                    fill="url(#fatGrad)"
+                    dot={{ r: 4, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }}
+                    activeDot={{ r: 6, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }}
+                  />
                 </AreaChart>
               </ResponsiveContainer>
+              <SingleMetricLegend label="% Gordura" color="#F97316" />
             </CardContent>
           </Card>
         </motion.div>
@@ -535,45 +616,15 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
 
       {circumferenceData.length > 0 && (
         <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.2 }}>
-          <SectionHeader icon={<Ruler className="h-3.5 w-3.5 text-purple-600" />} title="Circunferências (cm)" />
+          <SectionHeader
+            icon={<Ruler className="h-3.5 w-3.5 text-purple-600" />}
+            title="Circunferências (cm)"
+            subtitle="Comparação por medida entre a avaliação inicial e final selecionadas."
+          />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={circumferenceData.length * 38 + 20}>
-                <BarChart data={circumferenceData} layout="vertical" margin={{ top: 0, right: 40, left: 60, bottom: 0 }} barSize={10} barGap={3}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
-                  <XAxis type="number" tick={{ fontSize: 9, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} />
-                  <YAxis type="category" dataKey="label" tick={{ fontSize: 10, fill: "#64748b" }} axisLine={false} tickLine={false} width={58} />
-                  <Tooltip
-                    content={({ active, payload, label }) => {
-                      if (!active || !payload?.length) return null;
-                      return (
-                        <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
-                          <p className="text-xs text-muted-foreground mb-1">{label}</p>
-                          {payload.map((p: any) => (
-                            <p key={p.name} className="text-xs font-semibold" style={{ color: p.fill }}>
-                              {p.name === "atual" ? "Final" : "Inicial"}: {formatNumber(p.value)} cm
-                            </p>
-                          ))}
-                        </div>
-                      );
-                    }}
-                  />
-                  {comparisonStart && <Bar dataKey="inicial" name="inicial" fill="#C4B5FD" radius={[0, 4, 4, 0]} />}
-                  <Bar dataKey="atual" name="atual" fill="#8B5CF6" radius={[0, 4, 4, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
-        </motion.div>
-      )}
-
-      {foldData.length > 0 && (
-        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.25 }}>
-          <SectionHeader icon={<Activity className="h-3.5 w-3.5 text-rose-500" />} title="Dobras Cutâneas (mm)" />
-          <Card className="border border-gray-100 shadow-sm overflow-hidden">
-            <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={foldData.length * 38 + 20}>
-                <BarChart data={foldData} layout="vertical" margin={{ top: 0, right: 40, left: 72, bottom: 0 }} barSize={10} barGap={3}>
+              <ResponsiveContainer width="100%" height={Math.max(circumferenceData.length * 38 + 40, 240)}>
+                <BarChart data={circumferenceData} layout="vertical" margin={{ top: 0, right: 40, left: 72, bottom: 12 }} barSize={10} barGap={3}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
                   <XAxis type="number" tick={{ fontSize: 9, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} />
                   <YAxis type="category" dataKey="label" tick={{ fontSize: 10, fill: "#64748b" }} axisLine={false} tickLine={false} width={70} />
@@ -583,6 +634,51 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                       return (
                         <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
                           <p className="text-xs text-muted-foreground mb-1">{label}</p>
+                          <p className="text-[11px] text-muted-foreground">
+                            Inicial: {formatDate(comparisonStart?.createdAt)} • Final: {formatDate(comparisonEnd?.createdAt)}
+                          </p>
+                          {payload.map((p: any) => (
+                            <p key={p.name} className="text-xs font-semibold" style={{ color: p.fill }}>
+                              {p.name === "atual" ? "Final" : "Inicial"}: {formatNumber(p.value)} cm
+                            </p>
+                          ))}
+                        </div>
+                      );
+                    }}
+                  />
+                  <Legend verticalAlign="bottom" align="center" wrapperStyle={{ paddingTop: 8, fontSize: 11 }} />
+                  {comparisonStart && <Bar dataKey="inicial" name="Inicial" fill="#C4B5FD" radius={[0, 4, 4, 0]} />}
+                  <Bar dataKey="atual" name="Final" fill="#8B5CF6" radius={[0, 4, 4, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </motion.div>
+      )}
+
+      {foldData.length > 0 && (
+        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.25 }}>
+          <SectionHeader
+            icon={<Activity className="h-3.5 w-3.5 text-rose-500" />}
+            title="Dobras Cutâneas (mm)"
+            subtitle="Comparação por dobra entre a avaliação inicial e final selecionadas."
+          />
+          <Card className="border border-gray-100 shadow-sm overflow-hidden">
+            <CardContent className="px-2 pt-4 pb-2">
+              <ResponsiveContainer width="100%" height={Math.max(foldData.length * 38 + 40, 220)}>
+                <BarChart data={foldData} layout="vertical" margin={{ top: 0, right: 40, left: 72, bottom: 12 }} barSize={10} barGap={3}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
+                  <XAxis type="number" tick={{ fontSize: 9, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} />
+                  <YAxis type="category" dataKey="label" tick={{ fontSize: 10, fill: "#64748b" }} axisLine={false} tickLine={false} width={70} />
+                  <Tooltip
+                    content={({ active, payload, label }) => {
+                      if (!active || !payload?.length) return null;
+                      return (
+                        <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
+                          <p className="text-xs text-muted-foreground mb-1">{label}</p>
+                          <p className="text-[11px] text-muted-foreground">
+                            Inicial: {formatDate(comparisonStart?.createdAt)} • Final: {formatDate(comparisonEnd?.createdAt)}
+                          </p>
                           {payload.map((p: any) => (
                             <p key={p.name} className="text-xs font-semibold" style={{ color: p.fill }}>
                               {p.name === "atual" ? "Final" : "Inicial"}: {formatNumber(p.value)} mm
@@ -592,8 +688,9 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                       );
                     }}
                   />
-                  {comparisonStart && <Bar dataKey="inicial" name="inicial" fill="#FECDD3" radius={[0, 4, 4, 0]} />}
-                  <Bar dataKey="atual" name="atual" fill="#F43F5E" radius={[0, 4, 4, 0]} />
+                  <Legend verticalAlign="bottom" align="center" wrapperStyle={{ paddingTop: 8, fontSize: 11 }} />
+                  {comparisonStart && <Bar dataKey="inicial" name="Inicial" fill="#FECDD3" radius={[0, 4, 4, 0]} />}
+                  <Bar dataKey="atual" name="Final" fill="#F43F5E" radius={[0, 4, 4, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             </CardContent>
@@ -602,7 +699,11 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
       )}
 
       <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.3 }}>
-        <SectionHeader icon={<Calendar className="h-3.5 w-3.5 text-emerald-500" />} title="Histórico de Avaliações" />
+        <SectionHeader
+          icon={<Calendar className="h-3.5 w-3.5 text-emerald-500" />}
+          title="Histórico de Avaliações"
+          subtitle="A linha do tempo destaca avaliação mais recente e o intervalo de comparação selecionado."
+        />
         <div className="relative pl-5">
           <div className="absolute left-2 top-2 bottom-2 w-0.5 bg-gradient-to-b from-purple-300 via-purple-200 to-transparent rounded-full" />
           <div className="space-y-3">
@@ -610,6 +711,14 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
               const isMostRecent = idx === 0;
               const isSelectedStart = comparisonStart?.id === assessment.id;
               const isSelectedEnd = comparisonEnd?.id === assessment.id;
+
+              const emphasisClass = isSelectedStart
+                ? "border-blue-300 bg-blue-50/40"
+                : isSelectedEnd
+                ? "border-emerald-300 bg-emerald-50/40"
+                : isMostRecent
+                ? "border-purple-200 bg-purple-50/50"
+                : "border-gray-100";
 
               return (
                 <motion.div
@@ -619,8 +728,12 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                   transition={{ duration: 0.3, delay: idx * 0.05 }}
                   className="relative"
                 >
-                  <div className={`absolute -left-3.5 top-3.5 w-2.5 h-2.5 rounded-full border-2 border-white shadow-sm ${isMostRecent ? "bg-purple-600" : "bg-purple-200"}`} />
-                  <Card className={`border shadow-sm ml-1 ${isMostRecent ? "border-purple-200 bg-purple-50/50" : "border-gray-100"}`}>
+                  <div
+                    className={`absolute -left-3.5 top-3.5 w-2.5 h-2.5 rounded-full border-2 border-white shadow-sm ${
+                      isSelectedStart ? "bg-blue-500" : isSelectedEnd ? "bg-emerald-500" : isMostRecent ? "bg-purple-600" : "bg-purple-200"
+                    }`}
+                  />
+                  <Card className={`border shadow-sm ml-1 ${emphasisClass}`}>
                     <CardContent className="px-3.5 py-3">
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex-1 min-w-0">
@@ -634,10 +747,14 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                             </Badge>
                           )}
                           {isSelectedStart && (
-                            <Badge variant="outline" className="text-[10px]">Inicial</Badge>
+                            <Badge variant="outline" className="text-[10px] border-blue-300 text-blue-700 bg-blue-50">
+                              Inicial
+                            </Badge>
                           )}
                           {isSelectedEnd && (
-                            <Badge variant="outline" className="text-[10px]">Final</Badge>
+                            <Badge variant="outline" className="text-[10px] border-emerald-300 text-emerald-700 bg-emerald-50">
+                              Final
+                            </Badge>
                           )}
                         </div>
                       </div>
@@ -666,12 +783,6 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
           </div>
         </div>
       </motion.div>
-
-      {previousForEnd && (
-        <p className="text-[11px] text-muted-foreground text-center">
-          Dica: os gráficos de barras usam os valores final vs. inicial da comparação selecionada.
-        </p>
-      )}
     </div>
   );
 }

--- a/client/src/components/assessment-evolution.tsx
+++ b/client/src/components/assessment-evolution.tsx
@@ -1,327 +1,306 @@
-/**
- * AssessmentEvolution
- *
- * Componente de visualização da evolução das avaliações antropométricas.
- *
- * Funcionalidades:
- * - Gráfico de linha para evolução do peso ao longo do tempo
- * - Gráfico de área para % de gordura corporal
- * - Cards de comparação com indicadores delta (↑↓) entre última e penúltima avaliação
- * - Gráfico de barras horizontais para circunferências e dobras cutâneas
- * - Suporte a múltiplas avaliações com navegação por período
- *
- * Usa Recharts (já instalado) e Framer Motion para animações.
- * Zero dependências novas.
- */
-
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import {
-  LineChart,
-  Line,
-  AreaChart,
   Area,
-  BarChart,
+  AreaChart,
   Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  ReferenceLine,
 } from "recharts";
 import {
-  TrendingUp,
-  TrendingDown,
-  Minus,
-  Weight,
+  Activity,
+  ArrowDown,
+  ArrowRightLeft,
+  ArrowUp,
+  Calendar,
   Percent,
   Ruler,
-  Activity,
+  Weight,
 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { AnthropometricAssessment } from "@shared/schema";
 
 interface AssessmentEvolutionProps {
   history: AnthropometricAssessment[];
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
+type NumericMetricKey =
+  | "weightKg"
+  | "manualBodyFatPercent"
+  | "circumWaist"
+  | "circumHip"
+  | "circumAbdomen"
+  | "circumChest"
+  | "circumNeck"
+  | "circumNonDominantArmContracted"
+  | "circumNonDominantProximalThigh"
+  | "circumNonDominantCalf"
+  | "foldBiceps"
+  | "foldTriceps"
+  | "foldSubscapular"
+  | "foldSuprailiac";
+
+interface MetricDefinition {
+  key: NumericMetricKey;
+  label: string;
+  unit: "kg" | "%" | "cm" | "mm";
+  showPercentDiff?: boolean;
+}
+
+const METRIC_DEFINITIONS: MetricDefinition[] = [
+  { key: "weightKg", label: "Peso", unit: "kg", showPercentDiff: true },
+  { key: "manualBodyFatPercent", label: "% Gordura", unit: "%", showPercentDiff: true },
+  { key: "circumWaist", label: "Cintura", unit: "cm", showPercentDiff: true },
+  { key: "circumHip", label: "Quadril", unit: "cm", showPercentDiff: true },
+  { key: "circumAbdomen", label: "Abdômen", unit: "cm", showPercentDiff: true },
+  { key: "circumChest", label: "Tórax", unit: "cm", showPercentDiff: true },
+  { key: "circumNeck", label: "Pescoço", unit: "cm", showPercentDiff: true },
+  { key: "circumNonDominantArmContracted", label: "Braço (contraído)", unit: "cm", showPercentDiff: true },
+  { key: "circumNonDominantProximalThigh", label: "Coxa (proximal)", unit: "cm", showPercentDiff: true },
+  { key: "circumNonDominantCalf", label: "Panturrilha", unit: "cm", showPercentDiff: true },
+  { key: "foldBiceps", label: "Dobra Bicipital", unit: "mm" },
+  { key: "foldTriceps", label: "Dobra Tricipital", unit: "mm" },
+  { key: "foldSubscapular", label: "Dobra Subescapular", unit: "mm" },
+  { key: "foldSuprailiac", label: "Dobra Suprailíaca", unit: "mm" },
+];
+
+function toValidNumber(value: unknown): number | null {
+  if (typeof value !== "number" || Number.isNaN(value)) return null;
+  return value;
+}
+
+function toTimestamp(value: Date | string | null | undefined): number {
+  if (!value) return 0;
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
 
 function formatDate(date: Date | string | null | undefined): string {
-  if (!date) return "";
-  return new Date(date).toLocaleDateString("pt-BR", {
+  if (!date) return "Data não informada";
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return "Data inválida";
+  return parsed.toLocaleDateString("pt-BR", {
     day: "2-digit",
     month: "2-digit",
-    year: "2-digit",
+    year: "numeric",
   });
 }
 
-function formatDateFull(date: Date | string | null | undefined): string {
-  if (!date) return "";
-  return new Date(date).toLocaleDateString("pt-BR", {
+function formatDateLong(date: Date | string | null | undefined): string {
+  if (!date) return "Data não informada";
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return "Data inválida";
+  return parsed.toLocaleDateString("pt-BR", {
     day: "2-digit",
     month: "long",
     year: "numeric",
   });
 }
 
-type DeltaDirection = "up" | "down" | "neutral";
-
-function getDelta(
-  current: number | null | undefined,
-  previous: number | null | undefined
-): { value: number | null; direction: DeltaDirection } {
-  if (current == null || previous == null) return { value: null, direction: "neutral" };
-  const diff = parseFloat((current - previous).toFixed(2));
-  return {
-    value: diff,
-    direction: diff > 0 ? "up" : diff < 0 ? "down" : "neutral",
-  };
+function formatNumber(value: number, maxFractionDigits = 1): string {
+  return new Intl.NumberFormat("pt-BR", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: maxFractionDigits,
+  }).format(value);
 }
 
-// ─── Delta Card ─────────────────────────────────────────────────────────────
-
-interface DeltaCardProps {
-  label: string;
-  current: number | null | undefined;
-  previous: number | null | undefined;
-  unit: string;
-  icon: React.ReactNode;
-  positiveIsGood?: boolean; // se true, aumento é verde; se false, aumento é vermelho
-  gradient: string;
+function getDayDiff(start: Date | string | null | undefined, end: Date | string | null | undefined): number | null {
+  const startTs = toTimestamp(start);
+  const endTs = toTimestamp(end);
+  if (!startTs || !endTs || endTs < startTs) return null;
+  return Math.round((endTs - startTs) / (1000 * 60 * 60 * 24));
 }
 
-function DeltaCard({
-  label,
-  current,
-  previous,
-  unit,
-  icon,
-  positiveIsGood = false,
-  gradient,
-}: DeltaCardProps) {
-  const delta = getDelta(current, previous);
+function getVariation(current: number | null, previous: number | null) {
+  if (current == null || previous == null) {
+    return { absolute: null, percent: null as number | null, trend: "Sem comparação" };
+  }
 
-  const deltaColor =
-    delta.direction === "neutral"
-      ? "text-gray-400"
-      : delta.direction === "up"
-      ? positiveIsGood
-        ? "text-emerald-500"
-        : "text-rose-500"
-      : positiveIsGood
-      ? "text-rose-500"
-      : "text-emerald-500";
+  const absolute = Number((current - previous).toFixed(2));
+  const percent = previous === 0 ? null : Number((((current - previous) / previous) * 100).toFixed(2));
 
-  const DeltaIcon =
-    delta.direction === "up"
-      ? TrendingUp
-      : delta.direction === "down"
-      ? TrendingDown
-      : Minus;
+  const trend = absolute === 0 ? "Sem alteração" : absolute > 0 ? "Aumento" : "Redução";
 
-  if (current == null) return null;
-
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 16 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.35, ease: "easeOut" }}
-    >
-      <Card className="overflow-hidden border-0 shadow-md">
-        <div className={`h-1.5 w-full ${gradient}`} />
-        <CardContent className="px-4 py-3.5">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="w-7 h-7 rounded-lg bg-gray-50 flex items-center justify-center">
-              {icon}
-            </div>
-            <p className="text-xs text-muted-foreground font-medium">{label}</p>
-          </div>
-          <div className="flex items-end justify-between">
-            <p className="text-2xl font-bold text-foreground leading-none">
-              {current}
-              <span className="text-sm font-normal text-muted-foreground ml-1">{unit}</span>
-            </p>
-            {delta.value !== null && (
-              <div className={`flex items-center gap-0.5 ${deltaColor}`}>
-                <DeltaIcon className="h-3.5 w-3.5" />
-                <span className="text-xs font-semibold">
-                  {delta.value > 0 ? "+" : ""}
-                  {delta.value} {unit}
-                </span>
-              </div>
-            )}
-          </div>
-          {previous != null && (
-            <p className="text-[11px] text-muted-foreground/60 mt-1">
-              Anterior: {previous} {unit}
-            </p>
-          )}
-        </CardContent>
-      </Card>
-    </motion.div>
-  );
+  return { absolute, percent, trend };
 }
-
-// ─── Custom Tooltip ──────────────────────────────────────────────────────────
-
-function CustomTooltip({
-  active,
-  payload,
-  label,
-  unit,
-}: {
-  active?: boolean;
-  payload?: Array<{ value: number; color: string }>;
-  label?: string;
-  unit?: string;
-}) {
-  if (!active || !payload?.length) return null;
-  return (
-    <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
-      <p className="text-xs text-muted-foreground mb-1">{label}</p>
-      <p className="text-sm font-bold" style={{ color: payload[0].color }}>
-        {payload[0].value} {unit}
-      </p>
-    </div>
-  );
-}
-
-// ─── Section Header ──────────────────────────────────────────────────────────
 
 function SectionHeader({ icon, title }: { icon: React.ReactNode; title: string }) {
   return (
     <div className="flex items-center gap-2 mb-3">
-      <div className="w-7 h-7 rounded-lg bg-purple-50 flex items-center justify-center">
-        {icon}
-      </div>
+      <div className="w-7 h-7 rounded-lg bg-purple-50 flex items-center justify-center">{icon}</div>
       <p className="text-xs font-bold text-foreground uppercase tracking-widest">{title}</p>
     </div>
   );
 }
 
-// ─── Main Component ──────────────────────────────────────────────────────────
-
 export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
-  // Ordena do mais antigo para o mais recente
-  const sorted = useMemo(
-    () => [...history].sort((a, b) => new Date(a.createdAt!).getTime() - new Date(b.createdAt!).getTime()),
+  const sortedHistory = useMemo(
+    () => [...history].sort((a, b) => toTimestamp(a.createdAt) - toTimestamp(b.createdAt)),
     [history]
   );
 
-  const latest = sorted[sorted.length - 1];
-  const previous = sorted.length >= 2 ? sorted[sorted.length - 2] : null;
+  const firstAssessment = sortedHistory[0] ?? null;
+  const latestAssessment = sortedHistory[sortedHistory.length - 1] ?? null;
 
-  // ── Dados para gráfico de peso ──────────────────────────────────────────
+  const [fromId, setFromId] = useState<string>(firstAssessment?.id ?? "");
+  const [toId, setToId] = useState<string>(latestAssessment?.id ?? "");
+
+  useEffect(() => {
+    setFromId(firstAssessment?.id ?? "");
+    setToId(latestAssessment?.id ?? "");
+  }, [firstAssessment?.id, latestAssessment?.id]);
+
+  const fromIndex = sortedHistory.findIndex((item) => item.id === fromId);
+  const toIndex = sortedHistory.findIndex((item) => item.id === toId);
+
+  const safeFromIndex = fromIndex >= 0 ? fromIndex : 0;
+  const safeToIndex = toIndex >= 0 ? toIndex : Math.max(sortedHistory.length - 1, 0);
+
+  const compareStartIndex = Math.min(safeFromIndex, safeToIndex);
+  const compareEndIndex = Math.max(safeFromIndex, safeToIndex);
+
+  const comparisonStart = sortedHistory[compareStartIndex] ?? null;
+  const comparisonEnd = sortedHistory[compareEndIndex] ?? null;
+  const previousForEnd = compareEndIndex > 0 ? sortedHistory[compareEndIndex - 1] : null;
+
+  const dayInterval = getDayDiff(firstAssessment?.createdAt, latestAssessment?.createdAt);
+
+  const comparisonMetrics = useMemo(() => {
+    if (!comparisonStart || !comparisonEnd) return [];
+
+    return METRIC_DEFINITIONS
+      .map((metric) => {
+        const startValue = toValidNumber(comparisonStart[metric.key]);
+        const endValue = toValidNumber(comparisonEnd[metric.key]);
+        if (startValue == null || endValue == null) return null;
+
+        const variation = getVariation(endValue, startValue);
+
+        return {
+          ...metric,
+          startValue,
+          endValue,
+          variation,
+        };
+      })
+      .filter((metric): metric is NonNullable<typeof metric> => metric !== null);
+  }, [comparisonStart, comparisonEnd]);
+
   const weightData = useMemo(
     () =>
-      sorted
-        .filter((a) => a.weightKg != null)
-        .map((a) => ({
-          date: formatDate(a.createdAt),
-          dateFull: formatDateFull(a.createdAt),
-          peso: a.weightKg,
-          title: a.title,
-        })),
-    [sorted]
+      sortedHistory
+        .map((assessment) => ({
+          date: formatDate(assessment.createdAt),
+          dateLong: formatDateLong(assessment.createdAt),
+          title: assessment.title,
+          value: toValidNumber(assessment.weightKg),
+        }))
+        .filter((point) => point.value != null),
+    [sortedHistory]
   );
 
-  // ── Dados para gráfico de % gordura ────────────────────────────────────
   const fatData = useMemo(
     () =>
-      sorted
-        .filter((a) => a.manualBodyFatPercent != null && !Number.isNaN(a.manualBodyFatPercent))
-        .map((a) => ({
-          date: formatDate(a.createdAt),
-          dateFull: formatDateFull(a.createdAt),
-          gordura: a.manualBodyFatPercent,
-          title: a.title,
-        })),
-    [sorted]
+      sortedHistory
+        .map((assessment) => ({
+          date: formatDate(assessment.createdAt),
+          dateLong: formatDateLong(assessment.createdAt),
+          title: assessment.title,
+          value: toValidNumber(assessment.manualBodyFatPercent),
+        }))
+        .filter((point) => point.value != null),
+    [sortedHistory]
   );
 
-  // ── Dados para gráfico de circunferências (comparação últimas 2) ────────
-  const circumData = useMemo(() => {
-    if (!latest) return [];
-    const items = [
-      { label: "Pescoço", key: "circumNeck" as const },
-      { label: "Cintura", key: "circumWaist" as const },
-      { label: "Abdômen", key: "circumAbdomen" as const },
-      { label: "Quadril", key: "circumHip" as const },
-      { label: "Tórax", key: "circumChest" as const },
-      { label: "Braço", key: "circumNonDominantArmContracted" as const },
-      { label: "Coxa", key: "circumNonDominantProximalThigh" as const },
-      { label: "Panturrilha", key: "circumNonDominantCalf" as const },
-    ];
-    return items
-      .filter((item) => latest[item.key] != null)
-      .map((item) => ({
-        label: item.label,
-        atual: latest[item.key],
-        anterior: previous ? previous[item.key] : null,
-      }));
-  }, [latest, previous]);
+  const circumferenceData = useMemo(() => {
+    if (!comparisonEnd) return [];
 
-  // ── Dados para gráfico de dobras cutâneas ───────────────────────────────
+    return METRIC_DEFINITIONS
+      .filter((metric) => metric.unit === "cm")
+      .map((metric) => {
+        const endValue = toValidNumber(comparisonEnd[metric.key]);
+        const startValue = comparisonStart ? toValidNumber(comparisonStart[metric.key]) : null;
+        if (endValue == null) return null;
+
+        return {
+          label: metric.label,
+          atual: endValue,
+          inicial: startValue,
+        };
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null);
+  }, [comparisonEnd, comparisonStart]);
+
   const foldData = useMemo(() => {
-    if (!latest) return [];
-    const items = [
-      { label: "Bicipital", key: "foldBiceps" as const },
-      { label: "Tricipital", key: "foldTriceps" as const },
-      { label: "Subescapular", key: "foldSubscapular" as const },
-      { label: "Suprailíaca", key: "foldSuprailiac" as const },
-    ];
-    return items
-      .filter((item) => latest[item.key] != null)
-      .map((item) => ({
-        label: item.label,
-        atual: latest[item.key],
-        anterior: previous ? previous[item.key] : null,
-      }));
-  }, [latest, previous]);
+    if (!comparisonEnd) return [];
 
-  // ── Empty state ─────────────────────────────────────────────────────────
-  if (!latest) {
+    return METRIC_DEFINITIONS
+      .filter((metric) => metric.unit === "mm")
+      .map((metric) => {
+        const endValue = toValidNumber(comparisonEnd[metric.key]);
+        const startValue = comparisonStart ? toValidNumber(comparisonStart[metric.key]) : null;
+        if (endValue == null) return null;
+
+        return {
+          label: metric.label.replace("Dobra ", ""),
+          atual: endValue,
+          inicial: startValue,
+        };
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null);
+  }, [comparisonEnd, comparisonStart]);
+
+  if (!latestAssessment) {
     return (
       <Card className="border border-border/70">
         <CardContent className="flex flex-col items-center justify-center py-12 text-center">
           <Activity className="h-12 w-12 text-muted-foreground/50 mb-4" />
-          <p className="text-muted-foreground font-medium">Nenhuma avaliação disponível</p>
+          <p className="text-muted-foreground font-medium">Você ainda não possui avaliações registradas.</p>
           <p className="text-sm text-muted-foreground/70 mt-1">
-            Seu nutricionista irá registrar suas medidas para ativar a evolução.
+            Assim que uma avaliação for cadastrada, sua evolução será exibida aqui.
           </p>
         </CardContent>
       </Card>
     );
   }
 
-  // ── Single assessment state ─────────────────────────────────────────────
-  if (sorted.length === 1) {
+  if (sortedHistory.length === 1) {
     return (
       <div className="space-y-4">
         <Card className="border border-purple-100 bg-purple-50/40">
           <CardContent className="px-4 py-3 flex items-center gap-3">
             <div className="w-9 h-9 rounded-xl bg-purple-100 flex items-center justify-center">
-              <Activity className="h-4 w-4 text-purple-600" />
+              <Calendar className="h-4 w-4 text-purple-600" />
             </div>
             <div>
               <p className="text-sm font-semibold text-foreground">Primeira avaliação registrada</p>
               <p className="text-xs text-muted-foreground">
-                {formatDateFull(latest.createdAt)} — {latest.title}
+                {formatDateLong(latestAssessment.createdAt)} — {latestAssessment.title}
               </p>
             </div>
           </CardContent>
         </Card>
+
         <Card className="border border-border/50">
           <CardContent className="flex flex-col items-center justify-center py-10 text-center">
-            <TrendingUp className="h-10 w-10 text-purple-300 mb-3" />
-            <p className="text-sm font-medium text-muted-foreground">
-              Aguardando próxima avaliação
-            </p>
+            <ArrowRightLeft className="h-10 w-10 text-purple-300 mb-3" />
+            <p className="text-sm font-medium text-muted-foreground">Você possui uma avaliação registrada.</p>
             <p className="text-xs text-muted-foreground/70 mt-1">
-              Os gráficos de evolução serão exibidos após a segunda avaliação.
+              A comparação de evolução será exibida após uma nova avaliação.
             </p>
           </CardContent>
         </Card>
@@ -331,87 +310,161 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
 
   return (
     <div className="space-y-6">
-      {/* ── Header de resumo ─────────────────────────────────────────────── */}
       <motion.div
         initial={{ opacity: 0, y: -8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
-        className="flex items-center justify-between"
+        className="grid grid-cols-2 lg:grid-cols-4 gap-2.5"
       >
-        <div>
-          <p className="text-sm font-semibold text-foreground">Sua evolução</p>
-          <p className="text-xs text-muted-foreground">
-            {sorted.length} avaliação{sorted.length > 1 ? "ões" : ""} registrada{sorted.length > 1 ? "s" : ""}
-          </p>
-        </div>
-        <Badge
-          variant="secondary"
-          className="text-xs bg-purple-50 text-purple-700 border border-purple-100 font-medium"
-        >
-          Última: {formatDate(latest.createdAt)}
-        </Badge>
+        <Card className="border border-gray-100">
+          <CardContent className="p-3">
+            <p className="text-[11px] text-muted-foreground">Total de avaliações</p>
+            <p className="text-lg font-bold">{sortedHistory.length}</p>
+          </CardContent>
+        </Card>
+        <Card className="border border-gray-100">
+          <CardContent className="p-3">
+            <p className="text-[11px] text-muted-foreground">Primeira avaliação</p>
+            <p className="text-sm font-semibold leading-tight">{formatDate(firstAssessment?.createdAt)}</p>
+          </CardContent>
+        </Card>
+        <Card className="border border-gray-100">
+          <CardContent className="p-3">
+            <p className="text-[11px] text-muted-foreground">Última avaliação</p>
+            <p className="text-sm font-semibold leading-tight">{formatDate(latestAssessment?.createdAt)}</p>
+          </CardContent>
+        </Card>
+        <Card className="border border-gray-100">
+          <CardContent className="p-3">
+            <p className="text-[11px] text-muted-foreground">Período acompanhado</p>
+            <p className="text-sm font-semibold leading-tight">
+              {dayInterval == null ? "Não disponível" : `${dayInterval} dia${dayInterval === 1 ? "" : "s"}`}
+            </p>
+          </CardContent>
+        </Card>
       </motion.div>
 
-      {/* ── Cards de comparação (delta) ──────────────────────────────────── */}
+      <Card className="border border-purple-100 bg-purple-50/30">
+        <CardContent className="p-4 space-y-3">
+          <SectionHeader icon={<ArrowRightLeft className="h-3.5 w-3.5 text-purple-600" />} title="Comparação entre avaliações" />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Comparar de</Label>
+              <Select value={comparisonStart?.id ?? ""} onValueChange={setFromId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortedHistory.map((assessment) => (
+                    <SelectItem key={assessment.id} value={assessment.id}>
+                      {formatDate(assessment.createdAt)} • {assessment.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Comparar até</Label>
+              <Select value={comparisonEnd?.id ?? ""} onValueChange={setToId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortedHistory.map((assessment) => (
+                    <SelectItem key={assessment.id} value={assessment.id}>
+                      {formatDate(assessment.createdAt)} • {assessment.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {safeFromIndex > safeToIndex && (
+            <p className="text-xs text-amber-600">
+              A ordem foi ajustada automaticamente para manter uma comparação cronológica válida.
+            </p>
+          )}
+
+          <div className="text-xs text-muted-foreground">
+            Comparativo entre <strong>{formatDateLong(comparisonStart?.createdAt)}</strong> e{" "}
+            <strong>{formatDateLong(comparisonEnd?.createdAt)}</strong>.
+          </div>
+        </CardContent>
+      </Card>
+
       <div>
-        <SectionHeader
-          icon={<TrendingUp className="h-3.5 w-3.5 text-purple-600" />}
-          title="Comparação com avaliação anterior"
-        />
-        <div className="grid grid-cols-2 gap-2.5">
-          <DeltaCard
-            label="Peso"
-            current={latest.weightKg}
-            previous={previous?.weightKg}
-            unit="kg"
-            icon={<Weight className="h-3.5 w-3.5 text-blue-500" />}
-            positiveIsGood={false}
-            gradient="bg-gradient-to-r from-blue-400 to-blue-600"
-          />
-          <DeltaCard
-            label="% Gordura"
-            current={latest.manualBodyFatPercent}
-            previous={previous?.manualBodyFatPercent}
-            unit="%"
-            icon={<Percent className="h-3.5 w-3.5 text-orange-500" />}
-            positiveIsGood={false}
-            gradient="bg-gradient-to-r from-orange-400 to-amber-500"
-          />
-          <DeltaCard
-            label="Cintura"
-            current={latest.circumWaist}
-            previous={previous?.circumWaist}
-            unit="cm"
-            icon={<Ruler className="h-3.5 w-3.5 text-purple-500" />}
-            positiveIsGood={false}
-            gradient="bg-gradient-to-r from-purple-400 to-purple-600"
-          />
-          <DeltaCard
-            label="Quadril"
-            current={latest.circumHip}
-            previous={previous?.circumHip}
-            unit="cm"
-            icon={<Ruler className="h-3.5 w-3.5 text-pink-500" />}
-            positiveIsGood={false}
-            gradient="bg-gradient-to-r from-pink-400 to-rose-500"
-          />
-        </div>
+        <SectionHeader icon={<Activity className="h-3.5 w-3.5 text-indigo-600" />} title="Variação por métrica" />
+        {comparisonMetrics.length === 0 ? (
+          <Card className="border border-border/70">
+            <CardContent className="py-6 text-center text-sm text-muted-foreground">
+              Não há métricas numéricas completas para comparar nesse intervalo.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2.5">
+            {comparisonMetrics.map((metric) => {
+              const trendIcon =
+                metric.variation.absolute == null || metric.variation.absolute === 0 ? (
+                  <ArrowRightLeft className="h-3.5 w-3.5" />
+                ) : metric.variation.absolute > 0 ? (
+                  <ArrowUp className="h-3.5 w-3.5" />
+                ) : (
+                  <ArrowDown className="h-3.5 w-3.5" />
+                );
+
+              return (
+                <Card key={metric.key} className="border border-gray-100">
+                  <CardContent className="p-3 space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-semibold">{metric.label}</p>
+                      <Badge variant="secondary" className="text-[10px]">
+                        {metric.variation.trend}
+                      </Badge>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 text-xs">
+                      <div>
+                        <p className="text-muted-foreground">Inicial</p>
+                        <p className="font-semibold">
+                          {formatNumber(metric.startValue)} {metric.unit}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Final</p>
+                        <p className="font-semibold">
+                          {formatNumber(metric.endValue)} {metric.unit}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Variação</p>
+                        <p className="font-semibold flex items-center gap-1">
+                          {trendIcon}
+                          {metric.variation.absolute != null
+                            ? `${metric.variation.absolute > 0 ? "+" : ""}${formatNumber(metric.variation.absolute)} ${metric.unit}`
+                            : "—"}
+                        </p>
+                        {metric.showPercentDiff && metric.variation.percent != null && (
+                          <p className="text-[11px] text-muted-foreground">
+                            {metric.variation.percent > 0 ? "+" : ""}
+                            {formatNumber(metric.variation.percent, 2)}%
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
       </div>
 
-      {/* ── Gráfico de peso ──────────────────────────────────────────────── */}
       {weightData.length >= 2 && (
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.1 }}
-        >
-          <SectionHeader
-            icon={<Weight className="h-3.5 w-3.5 text-blue-500" />}
-            title="Evolução do Peso"
-          />
+        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.1 }}>
+          <SectionHeader icon={<Weight className="h-3.5 w-3.5 text-blue-500" />} title="Evolução do Peso" />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={180}>
+              <ResponsiveContainer width="100%" height={190}>
                 <AreaChart data={weightData} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
                   <defs>
                     <linearGradient id="weightGrad" x1="0" y1="0" x2="0" y2="1">
@@ -420,32 +473,22 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                     </linearGradient>
                   </defs>
                   <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" vertical={false} />
-                  <XAxis
-                    dataKey="date"
-                    tick={{ fontSize: 10, fill: "#94a3b8" }}
-                    axisLine={false}
-                    tickLine={false}
-                  />
-                  <YAxis
-                    tick={{ fontSize: 10, fill: "#94a3b8" }}
-                    axisLine={false}
-                    tickLine={false}
-                    domain={["auto", "auto"]}
-                  />
+                  <XAxis dataKey="date" tick={{ fontSize: 10, fill: "#94a3b8" }} axisLine={false} tickLine={false} />
+                  <YAxis tick={{ fontSize: 10, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} />
                   <Tooltip
-                    content={({ active, payload, label }) => (
-                      <CustomTooltip active={active} payload={payload as any} label={label} unit="kg" />
-                    )}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const point = payload[0]?.payload;
+                      return (
+                        <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
+                          <p className="text-xs text-muted-foreground">{point.dateLong}</p>
+                          <p className="text-[11px] text-muted-foreground">{point.title}</p>
+                          <p className="text-sm font-bold text-blue-600">{formatNumber(point.value)} kg</p>
+                        </div>
+                      );
+                    }}
                   />
-                  <Area
-                    type="monotone"
-                    dataKey="peso"
-                    stroke="#3B82F6"
-                    strokeWidth={2.5}
-                    fill="url(#weightGrad)"
-                    dot={{ r: 4, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }}
-                    activeDot={{ r: 6, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }}
-                  />
+                  <Area type="monotone" dataKey="value" stroke="#3B82F6" strokeWidth={2.5} fill="url(#weightGrad)" dot={{ r: 4, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }} activeDot={{ r: 6, fill: "#3B82F6", strokeWidth: 2, stroke: "#fff" }} />
                 </AreaChart>
               </ResponsiveContainer>
             </CardContent>
@@ -453,20 +496,12 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
         </motion.div>
       )}
 
-      {/* ── Gráfico de % gordura ─────────────────────────────────────────── */}
       {fatData.length >= 2 && (
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.15 }}
-        >
-          <SectionHeader
-            icon={<Percent className="h-3.5 w-3.5 text-orange-500" />}
-            title="Evolução da Gordura Corporal"
-          />
+        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.15 }}>
+          <SectionHeader icon={<Percent className="h-3.5 w-3.5 text-orange-500" />} title="Evolução da Gordura Corporal" />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={180}>
+              <ResponsiveContainer width="100%" height={190}>
                 <AreaChart data={fatData} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
                   <defs>
                     <linearGradient id="fatGrad" x1="0" y1="0" x2="0" y2="1">
@@ -475,33 +510,22 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                     </linearGradient>
                   </defs>
                   <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" vertical={false} />
-                  <XAxis
-                    dataKey="date"
-                    tick={{ fontSize: 10, fill: "#94a3b8" }}
-                    axisLine={false}
-                    tickLine={false}
-                  />
-                  <YAxis
-                    tick={{ fontSize: 10, fill: "#94a3b8" }}
-                    axisLine={false}
-                    tickLine={false}
-                    domain={["auto", "auto"]}
-                    tickFormatter={(v) => `${v}%`}
-                  />
+                  <XAxis dataKey="date" tick={{ fontSize: 10, fill: "#94a3b8" }} axisLine={false} tickLine={false} />
+                  <YAxis tick={{ fontSize: 10, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} tickFormatter={(v) => `${v}%`} />
                   <Tooltip
-                    content={({ active, payload, label }) => (
-                      <CustomTooltip active={active} payload={payload as any} label={label} unit="%" />
-                    )}
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null;
+                      const point = payload[0]?.payload;
+                      return (
+                        <div className="bg-white/95 backdrop-blur-sm border border-gray-100 rounded-xl px-3 py-2 shadow-lg">
+                          <p className="text-xs text-muted-foreground">{point.dateLong}</p>
+                          <p className="text-[11px] text-muted-foreground">{point.title}</p>
+                          <p className="text-sm font-bold text-orange-600">{formatNumber(point.value)}%</p>
+                        </div>
+                      );
+                    }}
                   />
-                  <Area
-                    type="monotone"
-                    dataKey="gordura"
-                    stroke="#F97316"
-                    strokeWidth={2.5}
-                    fill="url(#fatGrad)"
-                    dot={{ r: 4, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }}
-                    activeDot={{ r: 6, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }}
-                  />
+                  <Area type="monotone" dataKey="value" stroke="#F97316" strokeWidth={2.5} fill="url(#fatGrad)" dot={{ r: 4, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }} activeDot={{ r: 6, fill: "#F97316", strokeWidth: 2, stroke: "#fff" }} />
                 </AreaChart>
               </ResponsiveContainer>
             </CardContent>
@@ -509,43 +533,16 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
         </motion.div>
       )}
 
-      {/* ── Gráfico de circunferências ───────────────────────────────────── */}
-      {circumData.length > 0 && (
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.2 }}
-        >
-          <SectionHeader
-            icon={<Ruler className="h-3.5 w-3.5 text-purple-600" />}
-            title="Circunferências (cm)"
-          />
+      {circumferenceData.length > 0 && (
+        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.2 }}>
+          <SectionHeader icon={<Ruler className="h-3.5 w-3.5 text-purple-600" />} title="Circunferências (cm)" />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
-              <ResponsiveContainer width="100%" height={circumData.length * 38 + 20}>
-                <BarChart
-                  data={circumData}
-                  layout="vertical"
-                  margin={{ top: 0, right: 40, left: 60, bottom: 0 }}
-                  barSize={10}
-                  barGap={3}
-                >
+              <ResponsiveContainer width="100%" height={circumferenceData.length * 38 + 20}>
+                <BarChart data={circumferenceData} layout="vertical" margin={{ top: 0, right: 40, left: 60, bottom: 0 }} barSize={10} barGap={3}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
-                  <XAxis
-                    type="number"
-                    tick={{ fontSize: 9, fill: "#94a3b8" }}
-                    axisLine={false}
-                    tickLine={false}
-                    domain={["auto", "auto"]}
-                  />
-                  <YAxis
-                    type="category"
-                    dataKey="label"
-                    tick={{ fontSize: 10, fill: "#64748b" }}
-                    axisLine={false}
-                    tickLine={false}
-                    width={58}
-                  />
+                  <XAxis type="number" tick={{ fontSize: 9, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} />
+                  <YAxis type="category" dataKey="label" tick={{ fontSize: 10, fill: "#64748b" }} axisLine={false} tickLine={false} width={58} />
                   <Tooltip
                     content={({ active, payload, label }) => {
                       if (!active || !payload?.length) return null;
@@ -554,73 +551,32 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                           <p className="text-xs text-muted-foreground mb-1">{label}</p>
                           {payload.map((p: any) => (
                             <p key={p.name} className="text-xs font-semibold" style={{ color: p.fill }}>
-                              {p.name === "atual" ? "Atual" : "Anterior"}: {p.value} cm
+                              {p.name === "atual" ? "Final" : "Inicial"}: {formatNumber(p.value)} cm
                             </p>
                           ))}
                         </div>
                       );
                     }}
                   />
-                  {previous && (
-                    <Bar dataKey="anterior" name="anterior" fill="#C4B5FD" radius={[0, 4, 4, 0]} />
-                  )}
+                  {comparisonStart && <Bar dataKey="inicial" name="inicial" fill="#C4B5FD" radius={[0, 4, 4, 0]} />}
                   <Bar dataKey="atual" name="atual" fill="#8B5CF6" radius={[0, 4, 4, 0]} />
                 </BarChart>
               </ResponsiveContainer>
-              {previous && (
-                <div className="flex items-center gap-4 justify-center mt-2 pb-1">
-                  <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-3 rounded-sm bg-[#8B5CF6]" />
-                    <span className="text-[10px] text-muted-foreground">Atual</span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-3 rounded-sm bg-[#C4B5FD]" />
-                    <span className="text-[10px] text-muted-foreground">Anterior</span>
-                  </div>
-                </div>
-              )}
             </CardContent>
           </Card>
         </motion.div>
       )}
 
-      {/* ── Gráfico de dobras cutâneas ───────────────────────────────────── */}
       {foldData.length > 0 && (
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.25 }}
-        >
-          <SectionHeader
-            icon={<Activity className="h-3.5 w-3.5 text-rose-500" />}
-            title="Dobras Cutâneas (mm)"
-          />
+        <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.25 }}>
+          <SectionHeader icon={<Activity className="h-3.5 w-3.5 text-rose-500" />} title="Dobras Cutâneas (mm)" />
           <Card className="border border-gray-100 shadow-sm overflow-hidden">
             <CardContent className="px-2 pt-4 pb-2">
               <ResponsiveContainer width="100%" height={foldData.length * 38 + 20}>
-                <BarChart
-                  data={foldData}
-                  layout="vertical"
-                  margin={{ top: 0, right: 40, left: 72, bottom: 0 }}
-                  barSize={10}
-                  barGap={3}
-                >
+                <BarChart data={foldData} layout="vertical" margin={{ top: 0, right: 40, left: 72, bottom: 0 }} barSize={10} barGap={3}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
-                  <XAxis
-                    type="number"
-                    tick={{ fontSize: 9, fill: "#94a3b8" }}
-                    axisLine={false}
-                    tickLine={false}
-                    domain={["auto", "auto"]}
-                  />
-                  <YAxis
-                    type="category"
-                    dataKey="label"
-                    tick={{ fontSize: 10, fill: "#64748b" }}
-                    axisLine={false}
-                    tickLine={false}
-                    width={70}
-                  />
+                  <XAxis type="number" tick={{ fontSize: 9, fill: "#94a3b8" }} axisLine={false} tickLine={false} domain={["auto", "auto"]} />
+                  <YAxis type="category" dataKey="label" tick={{ fontSize: 10, fill: "#64748b" }} axisLine={false} tickLine={false} width={70} />
                   <Tooltip
                     content={({ active, payload, label }) => {
                       if (!active || !payload?.length) return null;
@@ -629,115 +585,93 @@ export function AssessmentEvolution({ history }: AssessmentEvolutionProps) {
                           <p className="text-xs text-muted-foreground mb-1">{label}</p>
                           {payload.map((p: any) => (
                             <p key={p.name} className="text-xs font-semibold" style={{ color: p.fill }}>
-                              {p.name === "atual" ? "Atual" : "Anterior"}: {p.value} mm
+                              {p.name === "atual" ? "Final" : "Inicial"}: {formatNumber(p.value)} mm
                             </p>
                           ))}
                         </div>
                       );
                     }}
                   />
-                  {previous && (
-                    <Bar dataKey="anterior" name="anterior" fill="#FECDD3" radius={[0, 4, 4, 0]} />
-                  )}
+                  {comparisonStart && <Bar dataKey="inicial" name="inicial" fill="#FECDD3" radius={[0, 4, 4, 0]} />}
                   <Bar dataKey="atual" name="atual" fill="#F43F5E" radius={[0, 4, 4, 0]} />
                 </BarChart>
               </ResponsiveContainer>
-              {previous && (
-                <div className="flex items-center gap-4 justify-center mt-2 pb-1">
-                  <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-3 rounded-sm bg-[#F43F5E]" />
-                    <span className="text-[10px] text-muted-foreground">Atual</span>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-3 rounded-sm bg-[#FECDD3]" />
-                    <span className="text-[10px] text-muted-foreground">Anterior</span>
-                  </div>
-                </div>
-              )}
             </CardContent>
           </Card>
         </motion.div>
       )}
 
-      {/* ── Timeline de avaliações ───────────────────────────────────────── */}
-      <motion.div
-        initial={{ opacity: 0, y: 16 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, delay: 0.3 }}
-      >
-        <SectionHeader
-          icon={<TrendingUp className="h-3.5 w-3.5 text-emerald-500" />}
-          title="Histórico de Avaliações"
-        />
+      <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.3 }}>
+        <SectionHeader icon={<Calendar className="h-3.5 w-3.5 text-emerald-500" />} title="Histórico de Avaliações" />
         <div className="relative pl-5">
-          {/* Linha vertical */}
           <div className="absolute left-2 top-2 bottom-2 w-0.5 bg-gradient-to-b from-purple-300 via-purple-200 to-transparent rounded-full" />
           <div className="space-y-3">
-            {[...sorted].reverse().map((assessment, idx) => (
-              <motion.div
-                key={assessment.id}
-                initial={{ opacity: 0, x: -8 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: 0.3, delay: idx * 0.05 }}
-                className="relative"
-              >
-                {/* Dot na linha */}
-                <div
-                  className={`absolute -left-3.5 top-3.5 w-2.5 h-2.5 rounded-full border-2 border-white shadow-sm ${
-                    idx === 0 ? "bg-purple-600" : "bg-purple-200"
-                  }`}
-                />
-                <Card
-                  className={`border shadow-sm ml-1 ${
-                    idx === 0
-                      ? "border-purple-200 bg-purple-50/50"
-                      : "border-gray-100"
-                  }`}
+            {[...sortedHistory].reverse().map((assessment, idx) => {
+              const isMostRecent = idx === 0;
+              const isSelectedStart = comparisonStart?.id === assessment.id;
+              const isSelectedEnd = comparisonEnd?.id === assessment.id;
+
+              return (
+                <motion.div
+                  key={assessment.id}
+                  initial={{ opacity: 0, x: -8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.3, delay: idx * 0.05 }}
+                  className="relative"
                 >
-                  <CardContent className="px-3.5 py-3">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-semibold text-foreground truncate">
-                          {assessment.title}
-                        </p>
-                        <p className="text-xs text-muted-foreground mt-0.5">
-                          {formatDateFull(assessment.createdAt)}
-                        </p>
+                  <div className={`absolute -left-3.5 top-3.5 w-2.5 h-2.5 rounded-full border-2 border-white shadow-sm ${isMostRecent ? "bg-purple-600" : "bg-purple-200"}`} />
+                  <Card className={`border shadow-sm ml-1 ${isMostRecent ? "border-purple-200 bg-purple-50/50" : "border-gray-100"}`}>
+                    <CardContent className="px-3.5 py-3">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-foreground truncate">{assessment.title}</p>
+                          <p className="text-xs text-muted-foreground mt-0.5">{formatDateLong(assessment.createdAt)}</p>
+                        </div>
+                        <div className="flex flex-col gap-1 items-end">
+                          {isMostRecent && (
+                            <Badge variant="secondary" className="text-[10px] bg-purple-100 text-purple-700 border-0 shrink-0">
+                              Mais recente
+                            </Badge>
+                          )}
+                          {isSelectedStart && (
+                            <Badge variant="outline" className="text-[10px]">Inicial</Badge>
+                          )}
+                          {isSelectedEnd && (
+                            <Badge variant="outline" className="text-[10px]">Final</Badge>
+                          )}
+                        </div>
                       </div>
-                      {idx === 0 && (
-                        <Badge
-                          variant="secondary"
-                          className="text-[10px] bg-purple-100 text-purple-700 border-0 shrink-0"
-                        >
-                          Mais recente
-                        </Badge>
-                      )}
-                    </div>
-                    {/* Mini resumo de métricas */}
-                    <div className="flex flex-wrap gap-2 mt-2">
-                      {assessment.weightKg != null && (
-                        <span className="text-[11px] bg-blue-50 text-blue-700 rounded-full px-2 py-0.5 font-medium">
-                          {assessment.weightKg} kg
-                        </span>
-                      )}
-                      {assessment.manualBodyFatPercent != null && (
-                        <span className="text-[11px] bg-orange-50 text-orange-700 rounded-full px-2 py-0.5 font-medium">
-                          {assessment.manualBodyFatPercent}% gordura
-                        </span>
-                      )}
-                      {assessment.circumWaist != null && (
-                        <span className="text-[11px] bg-purple-50 text-purple-700 rounded-full px-2 py-0.5 font-medium">
-                          Cintura: {assessment.circumWaist} cm
-                        </span>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
-            ))}
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {assessment.weightKg != null && (
+                          <span className="text-[11px] bg-blue-50 text-blue-700 rounded-full px-2 py-0.5 font-medium">
+                            {formatNumber(assessment.weightKg)} kg
+                          </span>
+                        )}
+                        {assessment.manualBodyFatPercent != null && !Number.isNaN(assessment.manualBodyFatPercent) && (
+                          <span className="text-[11px] bg-orange-50 text-orange-700 rounded-full px-2 py-0.5 font-medium">
+                            {formatNumber(assessment.manualBodyFatPercent)}% gordura
+                          </span>
+                        )}
+                        {assessment.circumWaist != null && (
+                          <span className="text-[11px] bg-purple-50 text-purple-700 rounded-full px-2 py-0.5 font-medium">
+                            Cintura: {formatNumber(assessment.circumWaist)} cm
+                          </span>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </motion.div>
+              );
+            })}
           </div>
         </div>
       </motion.div>
+
+      {previousForEnd && (
+        <p className="text-[11px] text-muted-foreground text-center">
+          Dica: os gráficos de barras usam os valores final vs. inicial da comparação selecionada.
+        </p>
+      )}
     </div>
   );
 }

--- a/client/src/pages/patient/assessments.tsx
+++ b/client/src/pages/patient/assessments.tsx
@@ -54,11 +54,10 @@ export default function AssessmentsPage() {
     retry: false,
   });
 
-  const { data: anthroHistory, isLoading: historyLoading } = useQuery<AnthropometricAssessment[]>({
+  const { data: anthroHistory, isLoading: historyLoading, isError: historyError } = useQuery<AnthropometricAssessment[]>({
     queryKey: ["/api/my-anthropometry/history"],
     queryFn: async () => {
       const res = await apiRequest("GET", "/api/my-anthropometry/history");
-      if (!res.ok) return [];
       return res.json();
     },
     retry: false,
@@ -308,6 +307,16 @@ export default function AssessmentsPage() {
                 <Skeleton className="h-48 w-full rounded-xl" />
                 <Skeleton className="h-48 w-full rounded-xl" />
               </div>
+            ) : historyError ? (
+              <Card className="border border-border/70">
+                <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+                  <Activity className="h-12 w-12 text-muted-foreground/50 mb-4" />
+                  <p className="text-muted-foreground font-medium">Não foi possível carregar a evolução</p>
+                  <p className="text-sm text-muted-foreground/70 mt-1">
+                    Tente novamente em alguns instantes.
+                  </p>
+                </CardContent>
+              </Card>
             ) : (
               <AssessmentEvolution history={anthroHistory ?? []} />
             )}


### PR DESCRIPTION
### Motivation
- Improve the patient-facing evolution area so users can view their full chronological history and compare first vs last (and optionally any two) without breaking existing flows or data.
- Provide safer handling of missing/invalid values, clearer charts/tooltips and explicit empty/single-assessment states while preserving existing routes, components, types and chart library.

### Description
- Reworked `AssessmentEvolution` to sort history defensively, add small utilities (`toTimestamp`, `toValidNumber`, `formatNumber`, `getVariation`, etc.), and build a `METRIC_DEFINITIONS` map to drive comparisons without changing schema. (file: `client/src/components/assessment-evolution.tsx`)
- Added default comparison window (first → last) plus manual selectors `Comparar de` / `Comparar até` that keep comparisons chronological and compute absolute/percent deltas only when both values exist. (file: `client/src/components/assessment-evolution.tsx`)
- Kept Recharts, improved chart tooltips, axis labels, responsiveness and guards so graphs render only for metrics with valid data and avoid `NaN`/`undefined` UI artifacts. (file: `client/src/components/assessment-evolution.tsx`)
- Added top summary cards (total, first, last, period) and updated empty / single-assessment messages; added an error state for the evolution tab in the assessments page by surfacing query errors. (files: `client/src/components/assessment-evolution.tsx`, `client/src/pages/patient/assessments.tsx`)

### Testing
- Built the production bundle with `npx vite build`, which completed successfully; bundles were generated without introducing new chart libraries. (success)
- Ran type checks with `npm run check`, which reported failures originating from pre-existing TypeScript issues in files outside the evolution changes and therefore are unrelated to this PR (type-check step failed due to unrelated files). (reported)
- Manual verification checklist prepared (states: no assessments, one assessment, multiple assessments, comparison selectors, charts with partial data, mobile/desktop responsiveness, authorization scope via existing endpoints) and the UI changes are isolated to the evolution view and the assessments page error UI. (manual)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3af5c3588331a18766d2ee17a1f7)