### PR TITLE
Adicionar controle manual de visibilidade de prescrição para paciente

### DIFF
--- a/client/src/pages/nutritionist/patient-details.tsx
+++ b/client/src/pages/nutritionist/patient-details.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
-  CheckCircle, Eye, FileText, Plus, Users, XCircle,
+  CheckCircle, Eye, EyeOff, FileText, Plus, Users, XCircle,
   Copy, History, User, Calendar, Ruler, Weight, Target, Activity,
   Heart, Stethoscope, Pill, Camera, Image, Smile, Trash2, FileDown,
   CreditCard, Upload, Download, ClipboardList, Pencil,
@@ -360,6 +360,40 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
     onError: () => {
       toast({ title: "Erro", description: "Não foi possível ativar o plano alimentar. Tente novamente.", variant: "destructive" });
       setPrescriptionToActivate(null);
+    },
+  });
+
+  const togglePrescriptionVisibilityMutation = useMutation({
+    mutationFn: async ({
+      prescriptionId,
+      isVisibleToPatient,
+    }: {
+      prescriptionId: string;
+      isVisibleToPatient: boolean;
+    }) => {
+      const response = await apiRequest(
+        "PATCH",
+        `/api/patients/${params.id}/prescriptions/${prescriptionId}/visibility`,
+        { isVisibleToPatient },
+      );
+      return response.json();
+    },
+    onSuccess: (_data, variables) => {
+      toast({
+        title: "Visibilidade atualizada",
+        description: variables.isVisibleToPatient
+          ? "A prescrição está visível para o paciente."
+          : "A prescrição foi ocultada do paciente.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/patients", params.id, "prescriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/patient/my-prescriptions"] });
+    },
+    onError: () => {
+      toast({
+        title: "Erro",
+        description: "Não foi possível atualizar a visibilidade da prescrição.",
+        variant: "destructive",
+      });
     },
   });
 
@@ -1024,6 +1058,14 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
             <div className="space-y-4">
               {prescriptions.map((prescription) => (
                 <div key={prescription.id} className="rounded-xl border border-blue-100 bg-gradient-to-r from-blue-50 to-indigo-50 p-4 hover:shadow-md transition-shadow">
+                  {(() => {
+                    const isVisibleToPatient = prescription.isVisibleToPatient !== false;
+                    const isTogglingVisibility =
+                      togglePrescriptionVisibilityMutation.isPending &&
+                      togglePrescriptionVisibilityMutation.variables?.prescriptionId === prescription.id;
+
+                    return (
+                      <>
                   <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-3">
                     <div className="flex items-center gap-3 min-w-0 flex-1">
                       <div className="p-2 bg-blue-100 rounded-lg flex-shrink-0">
@@ -1056,6 +1098,19 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
                         : "Rascunho"}
                     </Badge>
                   </div>
+                  <div className="mb-3">
+                    <Badge
+                      variant="outline"
+                      className={
+                        isVisibleToPatient
+                          ? "bg-emerald-50 text-emerald-700 border-emerald-200"
+                          : "bg-slate-100 text-slate-700 border-slate-300"
+                      }
+                      data-testid={`badge-prescription-visibility-${prescription.id}`}
+                    >
+                      {isVisibleToPatient ? "Visível para o paciente" : "Oculta do paciente"}
+                    </Badge>
+                  </div>
                   {prescription.generalNotes && (
                     <div className="mt-2 p-3 bg-white/70 rounded-lg">
                       <p className="text-sm text-gray-700">{prescription.generalNotes}</p>
@@ -1085,6 +1140,34 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
                     <Button variant="ghost" size="sm" onClick={() => handleDownloadPrescription(prescription.id)} data-testid={`button-download-prescription-${prescription.id}`} className="bg-green-100 hover:bg-green-200 text-green-700 border border-green-200 rounded-lg">
                       <FileDown className="h-4 w-4 mr-1" />Baixar
                     </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        togglePrescriptionVisibilityMutation.mutate({
+                          prescriptionId: prescription.id,
+                          isVisibleToPatient: !isVisibleToPatient,
+                        })
+                      }
+                      disabled={isTogglingVisibility}
+                      data-testid={`button-toggle-prescription-visibility-${prescription.id}`}
+                      className={
+                        isVisibleToPatient
+                          ? "bg-slate-100 hover:bg-slate-200 text-slate-700 border border-slate-300 rounded-lg"
+                          : "bg-emerald-100 hover:bg-emerald-200 text-emerald-700 border border-emerald-200 rounded-lg"
+                      }
+                    >
+                      {isVisibleToPatient ? (
+                        <EyeOff className="h-4 w-4 mr-1" />
+                      ) : (
+                        <Eye className="h-4 w-4 mr-1" />
+                      )}
+                      {isTogglingVisibility
+                        ? "Salvando..."
+                        : isVisibleToPatient
+                        ? "Ocultar do paciente"
+                        : "Exibir para paciente"}
+                    </Button>
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
                         <Button variant="ghost" size="sm" className="bg-red-50 hover:bg-red-100 text-red-700 border border-red-200 rounded-lg" data-testid={`button-delete-prescription-${prescription.id}`}>
@@ -1105,6 +1188,9 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
                       </AlertDialogContent>
                     </AlertDialog>
                   </div>
+                      </>
+                    );
+                  })()}
                 </div>
               ))}
             </div>

--- a/migrations/0015_prescription_visibility.sql
+++ b/migrations/0015_prescription_visibility.sql
@@ -1,0 +1,8 @@
+-- Migração: controle manual de visibilidade da prescrição para o paciente
+-- Regra: nutricionista sempre enxerga todas as prescrições; paciente enxerga apenas as visíveis.
+
+ALTER TABLE "prescriptions"
+  ADD COLUMN IF NOT EXISTS "is_visible_to_patient" boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN "prescriptions"."is_visible_to_patient" IS
+  'Controla se a prescrição deve ficar visível para o paciente. true=visível, false=oculta.';

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -723,18 +723,67 @@ export async function setupRoutes(app: Express): Promise<void> {
 
   app.get('/api/patients/:patientId/prescriptions', isAuthenticated, async (req, res) => {
     try {
-      const prescriptions = await storage.getPrescriptionsByPatient(req.params.patientId);
-      res.json(prescriptions);
+      const user = (req as any).user;
+      const patientId = req.params.patientId;
+      const patient = await storage.getPatient(patientId);
+
+      if (!patient) {
+        return res.status(404).json({ message: "Paciente não encontrado." });
+      }
+
+      if (user.role === "nutritionist") {
+        if (patient.ownerId !== user.id) {
+          return res.status(403).json({ message: "Acesso negado." });
+        }
+        const prescriptionList = await storage.getPrescriptionsByPatient(patientId);
+        return res.json(prescriptionList);
+      }
+
+      if (user.role === "patient") {
+        if (patient.userId !== user.id) {
+          return res.status(403).json({ message: "Acesso negado." });
+        }
+
+        const prescriptionList = await storage.getPrescriptionsByPatient(patientId);
+        return res.json(
+          prescriptionList.filter((p) => p.isVisibleToPatient !== false)
+        );
+      }
+
+      return res.status(403).json({ message: "Acesso negado." });
     } catch (error) {
       console.error("Erro ao buscar prescrições:", error);
       res.status(500).json({ message: "Falha ao buscar prescrições." });
     }
   });
   
-  app.get('/api/prescriptions/:id', isAuthenticated, async (req, res) => {
+  app.get('/api/prescriptions/:id', isAuthenticated, async (req: any, res) => {
     try {
+      const user = req.user;
       const prescription = await storage.getPrescription(req.params.id);
-      res.json(prescription);
+      if (!prescription) {
+        return res.status(404).json({ message: "Prescrição não encontrada." });
+      }
+
+      if (user.role === "nutritionist") {
+        if (prescription.nutritionistId !== user.id) {
+          return res.status(403).json({ message: "Acesso negado." });
+        }
+        return res.json(prescription);
+      }
+
+      if (user.role === "patient") {
+        const patient = await storage.getPatientByUserId(user.id);
+        if (!patient || prescription.patientId !== patient.id) {
+          return res.status(403).json({ message: "Acesso negado." });
+        }
+        if (prescription.isVisibleToPatient === false) {
+          return res.status(404).json({ message: "Prescrição não encontrada." });
+        }
+        return res.json(prescription);
+      }
+
+      res.status(403).json({ message: "Acesso negado." });
     } catch (error) {
       console.error("Erro ao buscar prescrição:", error);
       res.status(500).json({ message: "Falha ao buscar prescrição." });
@@ -821,6 +870,53 @@ export async function setupRoutes(app: Express): Promise<void> {
     } catch (error: any) {
       console.error('Error deactivating prescription:', error);
       res.status(500).json({ message: 'Failed to deactivate prescription' });
+    }
+  });
+
+  app.patch('/api/patients/:patientId/prescriptions/:prescriptionId/visibility', isAuthenticated, async (req: any, res) => {
+    try {
+      const user = req.user;
+      if (!user || user.role !== "nutritionist") {
+        return res.status(403).json({ message: "Apenas nutricionistas podem alterar a visibilidade." });
+      }
+
+      const patientId = req.params.patientId;
+      const prescriptionId = req.params.prescriptionId;
+      const parsedPayload = z.object({ isVisibleToPatient: z.boolean() }).safeParse(req.body);
+      if (!parsedPayload.success) {
+        return res.status(400).json({ message: "Payload inválido. Envie { isVisibleToPatient: boolean }." });
+      }
+
+      const patient = await storage.getPatient(patientId);
+      if (!patient) {
+        return res.status(404).json({ message: "Paciente não encontrado." });
+      }
+      if (patient.ownerId !== user.id) {
+        return res.status(403).json({ message: "Acesso negado." });
+      }
+
+      const prescription = await storage.getPrescription(prescriptionId);
+      if (!prescription || prescription.patientId !== patientId) {
+        return res.status(404).json({ message: "Prescrição não encontrada para este paciente." });
+      }
+      if (prescription.nutritionistId !== user.id) {
+        return res.status(403).json({ message: "Acesso negado." });
+      }
+
+      const updatedPrescription = await storage.updatePrescription(prescriptionId, {
+        isVisibleToPatient: parsedPayload.data.isVisibleToPatient,
+      });
+
+      logActivity({
+        userId: user.id,
+        activityType: 'update_prescription_visibility',
+        details: `Visibilidade da prescrição "${updatedPrescription.title}" definida como ${updatedPrescription.isVisibleToPatient ? 'visível' : 'oculta'} para o paciente.`,
+      });
+
+      return res.json(updatedPrescription);
+    } catch (error) {
+      console.error("Erro ao alterar visibilidade da prescrição:", error);
+      res.status(500).json({ message: "Falha ao alterar visibilidade da prescrição." });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -469,6 +469,7 @@ export class DatabaseStorage implements IStorage {
       .where(
         and(
           eq(prescriptions.patientId, patient.id),
+          eq(prescriptions.isVisibleToPatient, true),
           or(
             eq(prescriptions.status, "active"),
             eq(prescriptions.status, "published"),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -78,6 +78,7 @@ export const prescriptions = pgTable("prescriptions", {
   patientId: varchar("patient_id").references(() => patients.id, { onDelete: 'cascade' }).notNull(),
   nutritionistId: varchar("nutritionist_id").references(() => users.id).notNull(),
   title: text("title").notNull(),
+  isVisibleToPatient: boolean("is_visible_to_patient").notNull().default(true),
   status: varchar("status", { enum: ["draft", "preparing", "active", "published"] }).notNull().default("draft"),
   meals: jsonb("meals").$type<MealData[]>().notNull().default([]),
   generalNotes: text("general_notes"),


### PR DESCRIPTION
### Motivation

- Permitir que o nutricionista controle manualmente se uma prescrição deve aparecer imediatamente para o paciente sem depender apenas da validade/expiração. 
- Garantir que a regra seja aplicada no backend para não depender de ocultação apenas no frontend. 
- Manter a experiência do nutricionista (ver todas as prescrições) enquanto oculta prescrições para o paciente quando desejado. 
- Preservar a lógica de validade/expiração independente da nova visibilidade manual.

### Description

- Adicionado o campo de modelo `isVisibleToPatient` (`is_visible_to_patient` no banco) em `prescriptions` com `boolean NOT NULL DEFAULT true` e criada migração `migrations/0015_prescription_visibility.sql` para compatibilidade com dados existentes. 
- Atualizado o armazenamento (`server/storage.ts`) para filtrar prescrições visíveis ao buscar prescrições publicadas para o usuário paciente (`getPublishedPrescriptionsForUser`).
- Ajustadas rotas em `server/routes.ts` para diferenciar comportamento por papel: `GET /api/patients/:patientId/prescriptions` agora retorna todas para o nutricionista vinculado e somente prescrições com `isVisibleToPatient !== false` para o paciente; `GET /api/prescriptions/:id` aplica mesma diferenciação e oculta (404) prescrições invisíveis para o paciente. 
- Implementado novo endpoint seguro `PATCH /api/patients/:patientId/prescriptions/:prescriptionId/visibility` que valida autenticação, papel (somente nutricionistas), vínculo paciente↔nutricionista e prescrição↔paciente, e atualiza apenas o campo de visibilidade; registro de atividade adicionado. 
- Frontend (nutricionista): adicionado `useMutation` React Query e UI em `client/src/pages/nutritionist/patient-details.tsx` com badge `Visível para o paciente` / `Oculta do paciente`, botão Eye/EyeOff, loading por item, toast de sucesso/erro e invalidação das queries relevantes (`[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee65e144408331b440fe380b1ca758)