### PR TITLE
Corrige atualização imediata de prescrições (cache/invalidação)

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -81,7 +81,7 @@ self.addEventListener('fetch', (event) => {
   // ── API requests: Network-only (sem cache de respostas API) ──
   if (url.pathname.startsWith('/api/')) {
     event.respondWith(
-      fetch(request).catch(async () => (await caches.match(request)) || offlineResponse())
+      fetch(request).catch(() => offlineResponse())
     );
     return;
   }

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -12,11 +12,14 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
+  const normalizedMethod = method.toUpperCase();
   const res = await fetch(url, {
-    method,
+    method: normalizedMethod,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
     credentials: "include",
+    // Evita servir respostas antigas de cache HTTP em endpoints dinâmicos.
+    cache: normalizedMethod === "GET" ? "no-store" : "no-cache",
   });
 
   await throwIfResNotOk(res);
@@ -31,6 +34,8 @@ export const getQueryFn: <T>(options: {
   async ({ queryKey }) => {
     const res = await fetch(queryKey.join("/") as string, {
       credentials: "include",
+      // Query data crítica (plano, perfil, etc.) deve sempre consultar a rede.
+      cache: "no-store",
     });
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {

--- a/client/src/pages/nutritionist/patient-details.tsx
+++ b/client/src/pages/nutritionist/patient-details.tsx
@@ -336,6 +336,7 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
     onSuccess: () => {
       toast({ title: "Prescrição excluída", description: "A prescrição foi excluída com sucesso." });
       queryClient.invalidateQueries({ queryKey: ["/api/patients", params.id, "prescriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/patient/my-prescriptions"] });
       setPrescriptionToDelete(null);
     },
     onError: (error: any) => {
@@ -355,6 +356,7 @@ export default function PatientDetails({ params }: { params: { id: string } }) {
     onSuccess: () => {
       toast({ title: "Plano Ativado!", description: "O plano alimentar foi ativado com sucesso." });
       queryClient.invalidateQueries({ queryKey: ["/api/patients", params.id, "prescriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/patient/my-prescriptions"] });
       setPrescriptionToActivate(null);
     },
     onError: () => {

--- a/client/src/pages/nutritionist/prescription-editor.tsx
+++ b/client/src/pages/nutritionist/prescription-editor.tsx
@@ -101,6 +101,20 @@ export default function PrescriptionEditorPage({ params }: PrescriptionEditorPag
     return selectedPatientPrescriptions?.find(p => p.id === selectedPrescriptionId);
   }, [selectedPatientPrescriptions, selectedPrescriptionId]);
 
+  const invalidatePrescriptionQueries = () => {
+    const patientId = prescription?.patientId;
+
+    queryClient.invalidateQueries({ queryKey: ["/api/prescriptions", params.id] });
+    queryClient.invalidateQueries({ queryKey: ["/api/prescriptions"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/patient/my-prescriptions"] });
+    queryClient.invalidateQueries({ queryKey: ["/api/patients"] });
+
+    if (patientId) {
+      queryClient.invalidateQueries({ queryKey: ["/api/patients", patientId, "prescriptions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/patients", patientId] });
+    }
+  };
+
   const updatePrescriptionMutation = useMutation({
     mutationFn: async (data: { title: string; meals: MealData[]; generalNotes: string; expiresAt?: Date }) => {
       // Pass Date object directly - the backend validation will handle the conversion
@@ -115,7 +129,7 @@ export default function PrescriptionEditorPage({ params }: PrescriptionEditorPag
         title: "Sucesso",
         description: "Prescrição salva.",
       });
-      queryClient.invalidateQueries({ queryKey: ["/api/prescriptions", params.id] });
+      invalidatePrescriptionQueries();
     },
     onError: () => {
       toast({
@@ -137,7 +151,7 @@ export default function PrescriptionEditorPage({ params }: PrescriptionEditorPag
         title: "Sucesso",
         description: "Prescrição publicada com sucesso!",
       });
-      queryClient.invalidateQueries({ queryKey: ["/api/prescriptions", params.id] });
+      invalidatePrescriptionQueries();
       if (patient) {
         setLocation(`/patients/${patient.id}`);
       }
@@ -166,7 +180,7 @@ export default function PrescriptionEditorPage({ params }: PrescriptionEditorPag
         title: "Plano Ativado!",
         description: "O plano alimentar foi ativado e já está disponível para o paciente.",
       });
-      queryClient.invalidateQueries({ queryKey: ["/api/prescriptions", params.id] });
+      invalidatePrescriptionQueries();
       if (patient) {
         setLocation(`/patients/${patient.id}`);
       }
@@ -189,7 +203,7 @@ export default function PrescriptionEditorPage({ params }: PrescriptionEditorPag
         title: "Plano Desativado",
         description: "O plano alimentar foi desativado. O paciente não terá mais acesso.",
       });
-      queryClient.invalidateQueries({ queryKey: ["/api/prescriptions", params.id] });
+      invalidatePrescriptionQueries();
     },
     onError: () => {
       toast({

--- a/client/src/pages/patient/dashboard.tsx
+++ b/client/src/pages/patient/dashboard.tsx
@@ -207,6 +207,10 @@ export default function PatientDashboard() {
     },
     enabled: !!patientProfile?.id,
     retry: false,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 
   // Planos em preparação (status = "preparing")

--- a/client/src/pages/patient/prescription-view.tsx
+++ b/client/src/pages/patient/prescription-view.tsx
@@ -104,6 +104,10 @@ export default function PatientPrescriptionView() {
     queryKey: ["/api/patient/my-prescriptions"],
     enabled: !!user,
     retry: false,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 
   // Buscar dados do paciente para obter patientId - corrigido

--- a/client/src/pages/patient/prescriptions-list.tsx
+++ b/client/src/pages/patient/prescriptions-list.tsx
@@ -97,6 +97,10 @@ export default function PatientPrescriptionsList() {
     queryKey: ["/api/patient/my-prescriptions"],
     enabled: !!user,
     retry: false,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 
   // Buscar dados do paciente para obter patientId

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -118,6 +118,12 @@ const isAdmin = (req: any, res: any, next: any) => {
 };
 
 export async function setupRoutes(app: Express): Promise<void> {
+  const setNoStoreHeaders = (res: any) => {
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    res.setHeader('Surrogate-Control', 'no-store');
+  };
   await setupAuth(app);
   
   // Middleware para parsear o corpo da requisição de upload
@@ -723,6 +729,7 @@ export async function setupRoutes(app: Express): Promise<void> {
 
   app.get('/api/patients/:patientId/prescriptions', isAuthenticated, async (req, res) => {
     try {
+      setNoStoreHeaders(res);
       const user = (req as any).user;
       const patientId = req.params.patientId;
       const patient = await storage.getPatient(patientId);
@@ -759,6 +766,7 @@ export async function setupRoutes(app: Express): Promise<void> {
   
   app.get('/api/prescriptions/:id', isAuthenticated, async (req: any, res) => {
     try {
+      setNoStoreHeaders(res);
       const user = req.user;
       const prescription = await storage.getPrescription(req.params.id);
       if (!prescription) {
@@ -969,10 +977,7 @@ export async function setupRoutes(app: Express): Promise<void> {
 
   app.get('/api/patient/my-prescriptions', isAuthenticated, async (req: any, res) => {
     try {
-      // Adiciona headers de cache-control para garantir que dados sempre frescos sejam buscados
-      res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-      res.setHeader('Pragma', 'no-cache');
-      res.setHeader('Expires', '0');
+      setNoStoreHeaders(res);
       
       logActivity({ userId: req.user.id, activityType: 'view_my_prescriptions_list' });
 


### PR DESCRIPTION
### Motivation
- Corrigir atraso na aparição de alterações de prescrições para pacientes causado por cache HTTP/Service Worker e invalidação incompleta das queries após o nutricionista salvar/ativar/publicar um plano.

### Description
- Adiciona comportamento `no-store`/`no-cache` nas chamadas de fetch críticas no cliente (`client/src/lib/queryClient.ts`) para evitar respostas HTTP cacheadas para dados dinâmicos.
- Centraliza e amplia a invalidação de queries no editor de prescrições do nutricionista (`client/src/pages/nutritionist/prescription-editor.tsx`) via `invalidatePrescriptionQueries`, invalidando `['/api/prescriptions', id]`, `['/api/prescriptions']`, `['/api/patient/my-prescriptions']`, `['/api/patients']` e, se disponível, `['/api/patients', patientId, 'prescriptions']` e `['/api/patients', patientId]` após salvar/publish/activate/deactivate.
- Torna as telas do paciente mais agressivas em refetch: aplica `staleTime: 0`, `refetchOnMount: 'always'`, `refetchOnWindowFocus: true` e `refetchOnReconnect: true` em `client/src/pages/patient/prescriptions-list.tsx`, `client/src/pages/patient/prescription-view.tsx` e `client/src/pages/patient/dashboard.tsx` para garantir fetch imediato de versões novas.
- Define headers de cache seguros (`Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`, `Pragma`, `Expires`, `Surrogate-Control`) nos endpoints de prescrição no servidor (`server/routes.ts`) para reduzir risco de 304/respostas antigas.
- Ajusta o Service Worker (`client/public/sw.js`) para não servir respostas de API a partir do cache (network-only com fallback offline) e evita fallback cacheado que poderia devolver prescrições antigas.
- Pequena correção na página de detalhes do nutricionista (`client/src/pages/nutritionist/patient-details.tsx`) para também invalidar `['/api/patient/my-prescriptions']` ao ativar/excluir prescrição.
- Arquivos modificados: `client/src/lib/queryClient.ts`, `client/src/pages/nutritionist/prescription-editor.tsx`, `client/src/pages/nutritionist/patient-details.tsx`, `client/src/pages/patient/prescriptions-list.tsx`, `client/src/pages/patient/prescription-view.tsx`, `client/src/pages/patient/dashboard.tsx`, `client/public/sw.js`, `server/routes.ts`.

### Testing
- Executado `npx vite build` e a build completou com sucesso (artefatos gerados). ✅
- Executado `npm run check` (TypeScript check) que falhou devido a erros TypeScript pré-existentes no código base não relacionados às mudanças introduzidas; não foram adicionados novos erros escopados por estas alterações. ❌
- Observação: as mudanças focam em cache/invalidação/refetch e exigem teste manual de fluxo (nutricionista salvar → paciente abre/retorna à tela) e verificação em DevTools Network dos headers e chamadas a `/api/patient/my-prescriptions` conforme o roteiro de QA previamente definido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7d4d3c108331878074739ca6a0b2)